### PR TITLE
Use objects instead of tuples on tool input params

### DIFF
--- a/src/tools/category-search-tool/CategorySearchTool.test.ts
+++ b/src/tools/category-search-tool/CategorySearchTool.test.ts
@@ -98,6 +98,18 @@ describe('CategorySearchTool', () => {
     expect(calledUrl).toContain('proximity=-82.451668%2C27.942964');
   });
 
+  it('handles JSON-stringified object format proximity', async () => {
+    const mockFetch = setupFetch();
+
+    await new CategorySearchTool().run({
+      category: 'taco_shop',
+      proximity: '{"longitude": -82.458107, "latitude": 27.937259}'
+    });
+
+    const calledUrl = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('proximity=-82.458107%2C27.937259');
+  });
+
   it('uses default limit when not specified', async () => {
     const mockFetch = setupFetch();
 

--- a/src/tools/category-search-tool/CategorySearchTool.test.ts
+++ b/src/tools/category-search-tool/CategorySearchTool.test.ts
@@ -41,8 +41,13 @@ describe('CategorySearchTool', () => {
       category: 'hotel',
       language: 'es',
       limit: 15,
-      proximity: [-74.006, 40.7128],
-      bbox: [-74.1, 40.6, -73.9, 40.8],
+      proximity: { longitude: -74.006, latitude: 40.7128 },
+      bbox: {
+        minLongitude: -74.1,
+        minLatitude: 40.6,
+        maxLongitude: -73.9,
+        maxLatitude: 40.8
+      },
       country: ['US', 'CA'],
       poi_category_exclusions: ['motel', 'hostel']
     });
@@ -153,7 +158,7 @@ describe('CategorySearchTool', () => {
     await expect(
       tool.run({
         category: 'parking',
-        proximity: [-181, 40]
+        proximity: { longitude: -181, latitude: 40 }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -163,7 +168,12 @@ describe('CategorySearchTool', () => {
     await expect(
       tool.run({
         category: 'parking',
-        bbox: [-74, -91, -73, 40]
+        bbox: {
+          minLongitude: -74,
+          minLatitude: -91,
+          maxLongitude: -73,
+          maxLatitude: 40
+        }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -212,7 +222,8 @@ describe('CategorySearchTool', () => {
     expect(result.is_error).toBe(false);
     expect(result.content[0].type).toBe('text');
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Local Coffee Shop');
     expect(textContent).toContain('Address: 456 Oak St, Portland, OR 97205');
     expect(textContent).toContain('Coordinates: 45.515, -122.676');
@@ -249,7 +260,8 @@ describe('CategorySearchTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain("1. McDonalds (McDonald's)");
     expect(textContent).toContain('Address: 123 Main St, Boston, MA');
     expect(textContent).toContain('Coordinates: 42.3601, -71.0589');
@@ -280,7 +292,7 @@ describe('CategorySearchTool', () => {
           },
           geometry: {
             type: 'Point',
-            coordinates: [-122.340, 47.610]
+            coordinates: [-122.34, 47.61]
           }
         }
       ]
@@ -297,7 +309,8 @@ describe('CategorySearchTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Target');
     expect(textContent).toContain('2. Walmart');
     expect(textContent).toContain('100 Store St, Seattle, WA 98101');
@@ -320,7 +333,9 @@ describe('CategorySearchTool', () => {
 
     expect(result.is_error).toBe(false);
     expect(result.content[0].type).toBe('text');
-    expect((result.content[0] as { type: 'text'; text: string }).text).toBe('No results found.');
+    expect((result.content[0] as { type: 'text'; text: string }).text).toBe(
+      'No results found.'
+    );
   });
 
   it('handles results with minimal properties', async () => {
@@ -350,7 +365,8 @@ describe('CategorySearchTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Some Gas Station');
     expect(textContent).toContain('Coordinates: 40.7128, -74.006');
     expect(textContent).not.toContain('Address:');

--- a/src/tools/category-search-tool/CategorySearchTool.ts
+++ b/src/tools/category-search-tool/CategorySearchTool.ts
@@ -517,6 +517,22 @@ const CategorySearchInputSchema = z.object({
         if (val === 'ip') {
           return 'ip' as const;
         }
+        // Handle JSON-stringified object: "{\"longitude\": -82.458107, \"latitude\": 27.937259}"
+        if (val.startsWith('{') && val.endsWith('}')) {
+          try {
+            const parsed = JSON.parse(val);
+            if (
+              typeof parsed === 'object' &&
+              parsed !== null &&
+              typeof parsed.longitude === 'number' &&
+              typeof parsed.latitude === 'number'
+            ) {
+              return { longitude: parsed.longitude, latitude: parsed.latitude };
+            }
+          } catch {
+            // Fall back to other formats
+          }
+        }
         // Handle string that looks like an array: "[-82.451668, 27.942964]"
         if (val.startsWith('[') && val.endsWith(']')) {
           const coords = val

--- a/src/tools/directions-tool/DirectionsTool.test.ts
+++ b/src/tools/directions-tool/DirectionsTool.test.ts
@@ -18,8 +18,8 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        [-74.102094, 40.692815],
-        [-74.1022094, 40.792815]
+        { longitude: -74.102094, latitude: 40.692815 },
+        { longitude: -74.1022094, latitude: 40.792815 }
       ]
     });
 
@@ -31,8 +31,8 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        [-73.989, 40.733],
-        [-73.979, 40.743]
+        { longitude: -73.989, latitude: 40.733 },
+        { longitude: -73.979, latitude: 40.743 }
       ]
     });
 
@@ -48,9 +48,9 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        [-122.42, 37.78],
-        [-122.4, 37.79],
-        [-122.39, 37.77]
+        { longitude: -122.42, latitude: 37.78 },
+        { longitude: -122.4, latitude: 37.79 },
+        { longitude: -122.39, latitude: 37.77 }
       ],
       routing_profile: 'walking',
       geometries: 'geojson',
@@ -77,8 +77,8 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        [-118.24, 34.05],
-        [-118.3, 34.02]
+        { longitude: -118.24, latitude: 34.05 },
+        { longitude: -118.3, latitude: 34.02 }
       ]
     });
 
@@ -96,8 +96,8 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        [-74.0, 40.7],
-        [-73.9, 40.8]
+        { longitude: -74.0, latitude: 40.7 },
+        { longitude: -73.9, latitude: 40.8 }
       ],
       exclude: 'toll,point(-73.95 40.75)'
     });
@@ -122,8 +122,8 @@ describe('DirectionsTool', () => {
 
     const result = await new DirectionsTool().run({
       coordinates: [
-        [-73.989, 40.733],
-        [-73.979, 40.743]
+        { longitude: -73.989, latitude: 40.733 },
+        { longitude: -73.979, latitude: 40.743 }
       ]
     });
 
@@ -141,7 +141,7 @@ describe('DirectionsTool', () => {
     // Test with only one coordinate (invalid)
     await expect(
       tool.run({
-        coordinates: [[-73.989, 40.733]]
+        coordinates: [{ longitude: -73.989, latitude: 40.733 }]
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -161,7 +161,10 @@ describe('DirectionsTool', () => {
     const tool = new DirectionsTool();
 
     // Create an array of 26 coordinates (one more than allowed)
-    const tooManyCoords = Array(26).fill([-73.989, 40.733]);
+    const tooManyCoords = Array(26).fill({
+      longitude: -73.989,
+      latitude: 40.733
+    });
 
     await expect(
       tool.run({
@@ -177,8 +180,8 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        [-73.989, 40.733],
-        [-73.979, 40.743]
+        { longitude: -73.989, latitude: 40.733 },
+        { longitude: -73.979, latitude: 40.743 }
       ]
     });
 
@@ -193,7 +196,7 @@ describe('DirectionsTool', () => {
     // Create an array of exactly 25 coordinates (maximum allowed)
     const maxCoords = Array(25)
       .fill(0)
-      .map((_, i) => [-74 + i * 0.01, 40 + i * 0.01]);
+      .map((_, i) => ({ longitude: -74 + i * 0.01, latitude: 40 + i * 0.01 }));
 
     await new DirectionsTool().run({
       coordinates: maxCoords
@@ -203,7 +206,7 @@ describe('DirectionsTool', () => {
 
     // Check that all coordinates are properly encoded
     for (let i = 0; i < maxCoords.length; i++) {
-      const [lng, lat] = maxCoords[i];
+      const { longitude: lng, latitude: lat } = maxCoords[i];
       const semicolon = i < 24 ? '%3B' : '';
       const expectedCoord = `${lng}%2C${lat}` + semicolon;
       expect(calledUrl).toContain(expectedCoord);
@@ -218,8 +221,8 @@ describe('DirectionsTool', () => {
 
       await new DirectionsTool().run({
         coordinates: [
-          [-73.989, 40.733],
-          [-73.979, 40.743]
+          { longitude: -73.989, latitude: 40.733 },
+          { longitude: -73.979, latitude: 40.743 }
         ],
         routing_profile: 'walking',
         walking_speed: 2.5
@@ -235,8 +238,8 @@ describe('DirectionsTool', () => {
 
       await new DirectionsTool().run({
         coordinates: [
-          [-73.989, 40.733],
-          [-73.979, 40.743]
+          { longitude: -73.989, latitude: 40.733 },
+          { longitude: -73.979, latitude: 40.743 }
         ],
         routing_profile: 'walking',
         walkway_bias: 0.8
@@ -254,8 +257,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'driving',
           walking_speed: 2.0
@@ -268,8 +271,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'cycling',
           walking_speed: 2.0
@@ -286,8 +289,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'driving-traffic',
           walkway_bias: 0.5
@@ -300,8 +303,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'cycling',
           walkway_bias: -0.8
@@ -318,8 +321,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'walking',
           walking_speed: 0.1
@@ -332,8 +335,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'walking',
           walking_speed: 7.5
@@ -346,8 +349,8 @@ describe('DirectionsTool', () => {
       const mockFetch = setupFetch();
       await tool.run({
         coordinates: [
-          [-73.989, 40.733],
-          [-73.979, 40.743]
+          { longitude: -73.989, latitude: 40.733 },
+          { longitude: -73.979, latitude: 40.743 }
         ],
         routing_profile: 'walking',
         walking_speed: 3.0
@@ -363,8 +366,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'walking',
           walkway_bias: -1.5
@@ -377,8 +380,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'walking',
           walkway_bias: 1.2
@@ -391,8 +394,8 @@ describe('DirectionsTool', () => {
       const mockFetch = setupFetch();
       await tool.run({
         coordinates: [
-          [-73.989, 40.733],
-          [-73.979, 40.743]
+          { longitude: -73.989, latitude: 40.733 },
+          { longitude: -73.979, latitude: 40.743 }
         ],
         routing_profile: 'walking',
         walkway_bias: -0.5
@@ -411,8 +414,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'driving',
           exclude: 'toll,motorway,unpaved'
@@ -425,8 +428,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'driving-traffic',
           exclude: 'tunnel,country_border,state_border'
@@ -443,8 +446,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'walking',
           exclude: 'toll'
@@ -457,8 +460,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'cycling',
           exclude: 'motorway'
@@ -476,8 +479,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'driving',
           exclude: 'ferry'
@@ -490,8 +493,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'walking',
           exclude: 'ferry'
@@ -504,8 +507,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'cycling',
           exclude: 'cash_only_tolls'
@@ -523,8 +526,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'driving',
           exclude: 'point(-73.95 40.75)'
@@ -537,8 +540,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'walking',
           exclude: 'point(-73.95 40.75)'
@@ -551,8 +554,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'cycling',
           exclude: 'point(-73.95 40.75)'
@@ -570,8 +573,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'driving',
           exclude: 'toll,motorway,ferry,cash_only_tolls,point(-73.95 40.75)'
@@ -584,8 +587,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'walking',
           exclude: 'ferry,toll'
@@ -598,8 +601,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'cycling',
           exclude: 'ferry,cash_only_tolls'
@@ -620,8 +623,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'driving',
           depart_at: validDateTime
@@ -639,8 +642,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'driving-traffic',
           depart_at: validDateTime
@@ -664,8 +667,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              [-73.989, 40.733],
-              [-73.979, 40.743]
+              { longitude: -73.989, latitude: 40.733 },
+              { longitude: -73.979, latitude: 40.743 }
             ],
             routing_profile: 'driving',
             max_height: 4.5,
@@ -685,8 +688,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              [-73.989, 40.733],
-              [-73.979, 40.743]
+              { longitude: -73.989, latitude: 40.733 },
+              { longitude: -73.979, latitude: 40.743 }
             ],
             routing_profile: 'driving-traffic',
             max_height: 3.2
@@ -706,8 +709,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              [-73.989, 40.733],
-              [-73.979, 40.743]
+              { longitude: -73.989, latitude: 40.733 },
+              { longitude: -73.979, latitude: 40.743 }
             ],
             routing_profile: 'walking',
             max_height: 4.5
@@ -720,8 +723,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              [-73.989, 40.733],
-              [-73.979, 40.743]
+              { longitude: -73.989, latitude: 40.733 },
+              { longitude: -73.979, latitude: 40.743 }
             ],
             routing_profile: 'cycling',
             max_width: 2.0
@@ -738,8 +741,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              [-73.989, 40.733],
-              [-73.979, 40.743]
+              { longitude: -73.989, latitude: 40.733 },
+              { longitude: -73.979, latitude: 40.743 }
             ],
             routing_profile: 'driving',
             max_height: 15.0
@@ -752,8 +755,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              [-73.989, 40.733],
-              [-73.979, 40.743]
+              { longitude: -73.989, latitude: 40.733 },
+              { longitude: -73.979, latitude: 40.743 }
             ],
             routing_profile: 'driving',
             max_width: -1.0
@@ -766,8 +769,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              [-73.989, 40.733],
-              [-73.979, 40.743]
+              { longitude: -73.989, latitude: 40.733 },
+              { longitude: -73.979, latitude: 40.743 }
             ],
             routing_profile: 'driving',
             max_weight: 150.0
@@ -786,8 +789,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'walking',
           depart_at: validDateTime
@@ -800,8 +803,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            [-73.989, 40.733],
-            [-73.979, 40.743]
+            { longitude: -73.989, latitude: 40.733 },
+            { longitude: -73.979, latitude: 40.743 }
           ],
           routing_profile: 'cycling',
           depart_at: validDateTime
@@ -815,8 +818,8 @@ describe('DirectionsTool', () => {
       const mockFetch = setupFetch();
       const tool = new DirectionsTool();
       const baseCoordinates = [
-        [-73.989, 40.733],
-        [-73.979, 40.743]
+        { longitude: -73.989, latitude: 40.733 },
+        { longitude: -73.979, latitude: 40.743 }
       ];
 
       // Format 1: YYYY-MM-DDThh:mm:ssZ
@@ -853,8 +856,8 @@ describe('DirectionsTool', () => {
     it('rejects invalid date-time formats', async () => {
       const tool = new DirectionsTool();
       const baseCoordinates = [
-        [-73.989, 40.733],
-        [-73.979, 40.743]
+        { longitude: -73.989, latitude: 40.733 },
+        { longitude: -73.979, latitude: 40.743 }
       ];
 
       // Invalid format examples
@@ -885,8 +888,8 @@ describe('DirectionsTool', () => {
     it('rejects dates with invalid components', async () => {
       const tool = new DirectionsTool();
       const baseCoordinates = [
-        [-73.989, 40.733],
-        [-73.979, 40.743]
+        { longitude: -73.989, latitude: 40.733 },
+        { longitude: -73.979, latitude: 40.743 }
       ];
 
       // Invalid time components
@@ -919,8 +922,8 @@ describe('DirectionsTool', () => {
       // Test with driving profile - should work
       await new DirectionsTool().run({
         coordinates: [
-          [-74.1, 40.7],
-          [-74.2, 40.8]
+          { longitude: -74.1, latitude: 40.7 },
+          { longitude: -74.2, latitude: 40.8 }
         ],
         routing_profile: 'driving',
         arrive_by: validDateTime
@@ -939,8 +942,8 @@ describe('DirectionsTool', () => {
       // Test with driving-traffic profile
       const result1 = await new DirectionsTool().run({
         coordinates: [
-          [-74.1, 40.7],
-          [-74.2, 40.8]
+          { longitude: -74.1, latitude: 40.7 },
+          { longitude: -74.2, latitude: 40.8 }
         ],
         routing_profile: 'driving-traffic',
         arrive_by: validDateTime
@@ -951,8 +954,8 @@ describe('DirectionsTool', () => {
       // Test with walking profile
       const result2 = await new DirectionsTool().run({
         coordinates: [
-          [-74.1, 40.7],
-          [-74.2, 40.8]
+          { longitude: -74.1, latitude: 40.7 },
+          { longitude: -74.2, latitude: 40.8 }
         ],
         routing_profile: 'walking',
         arrive_by: validDateTime
@@ -963,8 +966,8 @@ describe('DirectionsTool', () => {
       // Test with cycling profile
       const result3 = await new DirectionsTool().run({
         coordinates: [
-          [-74.1, 40.7],
-          [-74.2, 40.8]
+          { longitude: -74.1, latitude: 40.7 },
+          { longitude: -74.2, latitude: 40.8 }
         ],
         routing_profile: 'cycling',
         arrive_by: validDateTime
@@ -976,8 +979,8 @@ describe('DirectionsTool', () => {
     it('rejects when both arrive_by and depart_at are provided', async () => {
       const result = await new DirectionsTool().run({
         coordinates: [
-          [-74.1, 40.7],
-          [-74.2, 40.8]
+          { longitude: -74.1, latitude: 40.7 },
+          { longitude: -74.2, latitude: 40.8 }
         ],
         routing_profile: 'driving',
         depart_at: '2025-06-05T09:30:00Z',
@@ -993,8 +996,8 @@ describe('DirectionsTool', () => {
       // Test with Z format
       await new DirectionsTool().run({
         coordinates: [
-          [-74.1, 40.7],
-          [-74.2, 40.8]
+          { longitude: -74.1, latitude: 40.7 },
+          { longitude: -74.2, latitude: 40.8 }
         ],
         routing_profile: 'driving',
         arrive_by: '2025-06-05T10:30:00Z'
@@ -1006,8 +1009,8 @@ describe('DirectionsTool', () => {
       // Test with timezone offset format
       await new DirectionsTool().run({
         coordinates: [
-          [-74.1, 40.7],
-          [-74.2, 40.8]
+          { longitude: -74.1, latitude: 40.7 },
+          { longitude: -74.2, latitude: 40.8 }
         ],
         routing_profile: 'driving',
         arrive_by: '2025-06-05T10:30:00+02:00'
@@ -1019,8 +1022,8 @@ describe('DirectionsTool', () => {
       // Test with simple time format (no seconds, no timezone)
       await new DirectionsTool().run({
         coordinates: [
-          [-74.1, 40.7],
-          [-74.2, 40.8]
+          { longitude: -74.1, latitude: 40.7 },
+          { longitude: -74.2, latitude: 40.8 }
         ],
         routing_profile: 'driving',
         arrive_by: '2025-06-05T10:30'
@@ -1052,8 +1055,8 @@ describe('DirectionsTool', () => {
       for (const format of invalidFormats) {
         const result = await new DirectionsTool().run({
           coordinates: [
-            [-74.1, 40.7],
-            [-74.2, 40.8]
+            { longitude: -74.1, latitude: 40.7 },
+            { longitude: -74.2, latitude: 40.8 }
           ],
           routing_profile: 'driving',
           arrive_by: format
@@ -1076,8 +1079,8 @@ describe('DirectionsTool', () => {
       for (const date of invalidDates) {
         const result = await new DirectionsTool().run({
           coordinates: [
-            [-74.1, 40.7],
-            [-74.2, 40.8]
+            { longitude: -74.1, latitude: 40.7 },
+            { longitude: -74.2, latitude: 40.8 }
           ],
           routing_profile: 'driving',
           arrive_by: date

--- a/src/tools/directions-tool/DirectionsTool.ts
+++ b/src/tools/directions-tool/DirectionsTool.ts
@@ -121,21 +121,21 @@ const validateIsoDateTime = (
 const DirectionsInputSchema = z.object({
   coordinates: z
     .array(
-      z.tuple([
-        z
+      z.object({
+        longitude: z
           .number()
           .min(-180, 'Longitude must be between -180 and 180 degrees')
           .max(180, 'Longitude must be between -180 and 180 degrees'),
-        z
+        latitude: z
           .number()
           .min(-90, 'Latitude must be between -90 and 90 degrees')
           .max(90, 'Latitude must be between -90 and 90 degrees')
-      ])
+      })
     )
     .min(2, 'At least two coordinate pairs are required.')
     .max(25, 'Up to 25 coordinate pairs are supported.')
     .describe(
-      'Array of [longitude, latitude] coordinate pairs to visit in order. ' +
+      'Array of coordinate objects with longitude and latitude properties to visit in order. ' +
         'Must include at least 2 coordinate pairs (starting and ending points). ' +
         'Up to 25 coordinates total are supported.'
     ),
@@ -436,7 +436,7 @@ export class DirectionsTool extends MapboxApiBasedTool<
     }
 
     const joined = input.coordinates
-      .map(([lng, lat]) => `${lng},${lat}`)
+      .map(({ longitude, latitude }) => `${longitude},${latitude}`)
       .join(';');
     const encodedCoords = encodeURIComponent(joined);
 

--- a/src/tools/forward-geocode-tool/ForwardGeocodeTool.test.ts
+++ b/src/tools/forward-geocode-tool/ForwardGeocodeTool.test.ts
@@ -113,6 +113,18 @@ describe('ForwardGeocodeTool', () => {
     expect(calledUrl).toContain('proximity=-82.451668%2C27.942964');
   });
 
+  it('handles JSON-stringified object format proximity', async () => {
+    const mockFetch = setupFetch();
+
+    await new ForwardGeocodeTool().run({
+      q: 'office',
+      proximity: '{"longitude": -82.458107, "latitude": 27.937259}'
+    });
+
+    const calledUrl = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('proximity=-82.458107%2C27.937259');
+  });
+
   it('handles fetch errors gracefully', async () => {
     const mockFetch = setupFetch({
       ok: false,

--- a/src/tools/forward-geocode-tool/ForwardGeocodeTool.test.ts
+++ b/src/tools/forward-geocode-tool/ForwardGeocodeTool.test.ts
@@ -44,12 +44,17 @@ describe('ForwardGeocodeTool', () => {
       q: 'restaurant',
       permanent: true,
       autocomplete: false,
-      bbox: [-74.1, 40.6, -73.9, 40.8],
+      bbox: {
+        minLongitude: -74.1,
+        minLatitude: 40.6,
+        maxLongitude: -73.9,
+        maxLatitude: 40.8
+      },
       country: ['US', 'CA'],
       format: 'geojson',
       language: 'es',
       limit: 3,
-      proximity: [-74.006, 40.7128],
+      proximity: { longitude: -74.006, latitude: 40.7128 },
       types: ['address', 'place'],
       worldview: 'cn'
     });
@@ -195,7 +200,7 @@ describe('ForwardGeocodeTool', () => {
     await expect(
       tool.run({
         q: 'test',
-        proximity: [-181, 40]
+        proximity: { longitude: -181, latitude: 40 }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -205,7 +210,12 @@ describe('ForwardGeocodeTool', () => {
     await expect(
       tool.run({
         q: 'test',
-        bbox: [-74, -91, -73, 40]
+        bbox: {
+          minLongitude: -74,
+          minLatitude: -91,
+          maxLongitude: -73,
+          maxLatitude: 40
+        }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -273,9 +283,12 @@ describe('ForwardGeocodeTool', () => {
     expect(result.is_error).toBe(false);
     expect(result.content[0].type).toBe('text');
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Seattle');
-    expect(textContent).toContain('Address: Seattle, Washington, United States');
+    expect(textContent).toContain(
+      'Address: Seattle, Washington, United States'
+    );
     expect(textContent).toContain('Coordinates: 47.608013, -122.335167');
     expect(textContent).toContain('Type: place');
   });
@@ -309,7 +322,8 @@ describe('ForwardGeocodeTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. NYC (New York City)');
     expect(textContent).toContain('Address: New York, NY, United States');
     expect(textContent).toContain('Coordinates: 40.7128, -74.0059');
@@ -357,7 +371,8 @@ describe('ForwardGeocodeTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Springfield');
     expect(textContent).toContain('2. Springfield');
     expect(textContent).toContain('Springfield, Illinois, United States');
@@ -380,7 +395,9 @@ describe('ForwardGeocodeTool', () => {
 
     expect(result.is_error).toBe(false);
     expect(result.content[0].type).toBe('text');
-    expect((result.content[0] as { type: 'text'; text: string }).text).toBe('No results found.');
+    expect((result.content[0] as { type: 'text'; text: string }).text).toBe(
+      'No results found.'
+    );
   });
 
   it('handles results with minimal properties', async () => {
@@ -410,7 +427,8 @@ describe('ForwardGeocodeTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Some Place');
     expect(textContent).toContain('Coordinates: 35.456, -100.123');
     expect(textContent).not.toContain('Address:');

--- a/src/tools/forward-geocode-tool/ForwardGeocodeTool.ts
+++ b/src/tools/forward-geocode-tool/ForwardGeocodeTool.ts
@@ -68,6 +68,22 @@ const ForwardGeocodeInputSchema = z.object({
         if (val === 'ip') {
           return 'ip' as const;
         }
+        // Handle JSON-stringified object: "{\"longitude\": -82.458107, \"latitude\": 27.937259}"
+        if (val.startsWith('{') && val.endsWith('}')) {
+          try {
+            const parsed = JSON.parse(val);
+            if (
+              typeof parsed === 'object' &&
+              parsed !== null &&
+              typeof parsed.longitude === 'number' &&
+              typeof parsed.latitude === 'number'
+            ) {
+              return { longitude: parsed.longitude, latitude: parsed.latitude };
+            }
+          } catch {
+            // Fall back to other formats
+          }
+        }
         // Handle string that looks like an array: "[-82.451668, 27.942964]"
         if (val.startsWith('[') && val.endsWith(']')) {
           const coords = val

--- a/src/tools/forward-geocode-tool/ForwardGeocodeTool.ts
+++ b/src/tools/forward-geocode-tool/ForwardGeocodeTool.ts
@@ -27,16 +27,14 @@ const ForwardGeocodeInputSchema = z.object({
     .default(true)
     .describe('Return partial/suggested results for partial queries'),
   bbox: z
-    .tuple([
-      z.number().min(-180).max(180),
-      z.number().min(-90).max(90),
-      z.number().min(-180).max(180),
-      z.number().min(-90).max(90)
-    ])
+    .object({
+      minLongitude: z.number().min(-180).max(180),
+      minLatitude: z.number().min(-90).max(90),
+      maxLongitude: z.number().min(-180).max(180),
+      maxLatitude: z.number().min(-90).max(90)
+    })
     .optional()
-    .describe(
-      'Bounding box to limit results within [minLon, minLat, maxLon, maxLat]'
-    ),
+    .describe('Bounding box to limit results within specified bounds'),
   country: z
     .array(z.string().length(2))
     .optional()
@@ -61,7 +59,10 @@ const ForwardGeocodeInputSchema = z.object({
     .describe('Maximum number of results to return (1-10)'),
   proximity: z
     .union([
-      z.tuple([z.number().min(-180).max(180), z.number().min(-90).max(90)]),
+      z.object({
+        longitude: z.number().min(-180).max(180),
+        latitude: z.number().min(-90).max(90)
+      }),
       z.string().transform((val) => {
         // Handle special case of 'ip'
         if (val === 'ip') {
@@ -74,16 +75,16 @@ const ForwardGeocodeInputSchema = z.object({
             .split(',')
             .map((s) => Number(s.trim()));
           if (coords.length === 2 && !isNaN(coords[0]) && !isNaN(coords[1])) {
-            return coords as [number, number];
+            return { longitude: coords[0], latitude: coords[1] };
           }
         }
         // Handle comma-separated string: "-82.451668,27.942964"
         const parts = val.split(',').map((s) => Number(s.trim()));
         if (parts.length === 2 && !isNaN(parts[0]) && !isNaN(parts[1])) {
-          return parts as [number, number];
+          return { longitude: parts[0], latitude: parts[1] };
         }
         throw new Error(
-          'Invalid proximity format. Expected [longitude, latitude], "longitude,latitude", or "ip"'
+          'Invalid proximity format. Expected {longitude, latitude}, "longitude,latitude", or "ip"'
         );
       })
     ])
@@ -193,10 +194,11 @@ export class ForwardGeocodeTool extends MapboxApiBasedTool<
     url.searchParams.append('worldview', input.worldview);
 
     if (input.bbox) {
-      const [minLon, minLat, maxLon, maxLat] = input.bbox;
+      const { minLongitude, minLatitude, maxLongitude, maxLatitude } =
+        input.bbox;
       url.searchParams.append(
         'bbox',
-        `${minLon},${minLat},${maxLon},${maxLat}`
+        `${minLongitude},${minLatitude},${maxLongitude},${maxLatitude}`
       );
     }
 
@@ -212,8 +214,8 @@ export class ForwardGeocodeTool extends MapboxApiBasedTool<
       if (input.proximity === 'ip') {
         url.searchParams.append('proximity', 'ip');
       } else {
-        const [lng, lat] = input.proximity;
-        url.searchParams.append('proximity', `${lng},${lat}`);
+        const { longitude, latitude } = input.proximity;
+        url.searchParams.append('proximity', `${longitude},${latitude}`);
       }
     }
 

--- a/src/tools/isochrone-tool/IsochroneTool.test.ts
+++ b/src/tools/isochrone-tool/IsochroneTool.test.ts
@@ -18,7 +18,7 @@ describe('IsochroneTool', () => {
     const mockFetch = setupFetch();
 
     await new IsochroneTool().run({
-      coordinates: [-74.006, 40.7128],
+      coordinates: { longitude: -74.006, latitude: 40.7128 },
       profile: 'mapbox/driving',
       contours_minutes: [10],
       generalize: 1000
@@ -33,7 +33,7 @@ describe('IsochroneTool', () => {
       json: async () => ({ type: 'FeatureCollection', features: [] })
     });
     await new IsochroneTool().run({
-      coordinates: [27.534527, 53.9353451],
+      coordinates: { longitude: 27.534527, latitude: 53.9353451 },
       profile: 'mapbox/driving',
       contours_minutes: [10, 20],
       contours_colors: ['ff0000', '00ff00'],
@@ -63,7 +63,7 @@ describe('IsochroneTool', () => {
       json: async () => ({ type: 'FeatureCollection', features: [] })
     });
     await new IsochroneTool().run({
-      coordinates: [27.534527, 53.9353451],
+      coordinates: { longitude: 27.534527, latitude: 53.9353451 },
       profile: 'mapbox/driving',
       contours_minutes: [10, 20],
       generalize: 1000
@@ -88,7 +88,7 @@ describe('IsochroneTool', () => {
     });
 
     const result = await new IsochroneTool().run({
-      coordinates: [-74.006, 40.7128],
+      coordinates: { longitude: -74.006, latitude: 40.7128 },
       profile: 'mapbox/walking',
       contours_minutes: [5],
       generalize: 1000
@@ -104,7 +104,7 @@ describe('IsochroneTool', () => {
   it('throws on invalid input', async () => {
     const tool = new IsochroneTool();
     const result = await tool.run({
-      coordinates: [0, 0],
+      coordinates: { longitude: 0, latitude: 0 },
       profile: 'invalid',
       contours_minutes: [5]
     });
@@ -117,7 +117,7 @@ describe('IsochroneTool', () => {
 
   it('throws if neither contours_minutes nor contours_meters is specified', async () => {
     const result = await new IsochroneTool().run({
-      coordinates: [-74.006, 40.7128],
+      coordinates: { longitude: -74.006, latitude: 40.7128 },
       profile: 'mapbox/driving',
       generalize: 1000
     });

--- a/src/tools/isochrone-tool/IsochroneTool.ts
+++ b/src/tools/isochrone-tool/IsochroneTool.ts
@@ -12,9 +12,12 @@ const IsochroneInputSchema = z.object({
     .default('mapbox/driving-traffic')
     .describe('Mode of travel.'),
   coordinates: z
-    .tuple([z.number().min(-180).max(180), z.number().min(-90).max(90)])
+    .object({
+      longitude: z.number().min(-180).max(180),
+      latitude: z.number().min(-90).max(90)
+    })
     .describe(
-      'A coordinate [longitude, latitude] pair around which to center the isochrone lines. Longitude: -180 to 180, Latitude: -85.0511 to 85.0511'
+      'A coordinate object with longitude and latitude properties around which to center the isochrone lines. Longitude: -180 to 180, Latitude: -85.0511 to 85.0511'
     ),
 
   contours_minutes: z
@@ -98,7 +101,7 @@ export class IsochroneTool extends MapboxApiBasedTool<
     input: z.infer<typeof IsochroneInputSchema>
   ): Promise<any> {
     const url = new URL(
-      `${MapboxApiBasedTool.MAPBOX_API_ENDPOINT}isochrone/v1/${input.profile}/${input.coordinates[0]}%2C${input.coordinates[1]}`
+      `${MapboxApiBasedTool.MAPBOX_API_ENDPOINT}isochrone/v1/${input.profile}/${input.coordinates.longitude}%2C${input.coordinates.latitude}`
     );
     url.searchParams.append(
       'access_token',

--- a/src/tools/matrix-tool/MatrixTool.test.ts
+++ b/src/tools/matrix-tool/MatrixTool.test.ts
@@ -70,8 +70,8 @@ describe('MatrixTool', () => {
 
     await new MatrixTool().run({
       coordinates: [
-        [-74.102094, 40.692815],
-        [-74.1022094, 40.792815]
+        { longitude: -74.102094, latitude: 40.692815 },
+        { longitude: -74.1022094, latitude: 40.792815 }
       ],
       profile: 'walking'
     });
@@ -87,9 +87,9 @@ describe('MatrixTool', () => {
     const tool = new MatrixTool();
     const result = await tool.run({
       coordinates: [
-        [-122.42, 37.78],
-        [-122.45, 37.91],
-        [-122.48, 37.73]
+        { longitude: -122.42, latitude: 37.78 },
+        { longitude: -122.45, latitude: 37.91 },
+        { longitude: -122.48, latitude: 37.73 }
       ],
       profile: 'driving'
     });
@@ -115,8 +115,8 @@ describe('MatrixTool', () => {
     const tool = new MatrixTool();
     await tool.run({
       coordinates: [
-        [-122.42, 37.78],
-        [-122.45, 37.91]
+        { longitude: -122.42, latitude: 37.78 },
+        { longitude: -122.45, latitude: 37.91 }
       ],
       profile: 'driving',
       annotations: 'duration,distance'
@@ -134,9 +134,9 @@ describe('MatrixTool', () => {
     const tool = new MatrixTool();
     await tool.run({
       coordinates: [
-        [-122.42, 37.78],
-        [-122.45, 37.91],
-        [-122.48, 37.73]
+        { longitude: -122.42, latitude: 37.78 },
+        { longitude: -122.45, latitude: 37.91 },
+        { longitude: -122.48, latitude: 37.73 }
       ],
       profile: 'driving',
       approaches: 'curb;unrestricted;curb'
@@ -154,8 +154,8 @@ describe('MatrixTool', () => {
     const tool = new MatrixTool();
     await tool.run({
       coordinates: [
-        [-122.42, 37.78],
-        [-122.45, 37.91]
+        { longitude: -122.42, latitude: 37.78 },
+        { longitude: -122.45, latitude: 37.91 }
       ],
       profile: 'driving',
       bearings: '45,90;120,45'
@@ -173,9 +173,9 @@ describe('MatrixTool', () => {
     const tool = new MatrixTool();
     await tool.run({
       coordinates: [
-        [-122.42, 37.78],
-        [-122.45, 37.91],
-        [-122.48, 37.73]
+        { longitude: -122.42, latitude: 37.78 },
+        { longitude: -122.45, latitude: 37.91 },
+        { longitude: -122.48, latitude: 37.73 }
       ],
       profile: 'cycling',
       destinations: '0;2'
@@ -193,9 +193,9 @@ describe('MatrixTool', () => {
     const tool = new MatrixTool();
     await tool.run({
       coordinates: [
-        [-122.42, 37.78],
-        [-122.45, 37.91],
-        [-122.48, 37.73]
+        { longitude: -122.42, latitude: 37.78 },
+        { longitude: -122.45, latitude: 37.91 },
+        { longitude: -122.48, latitude: 37.73 }
       ],
       profile: 'walking',
       sources: '1'
@@ -213,9 +213,9 @@ describe('MatrixTool', () => {
     const tool = new MatrixTool();
     const result = await tool.run({
       coordinates: [
-        [-122.42, 37.78],
-        [-122.45, 37.91],
-        [-122.48, 37.73]
+        { longitude: -122.42, latitude: 37.78 },
+        { longitude: -122.45, latitude: 37.91 },
+        { longitude: -122.48, latitude: 37.73 }
       ],
       profile: 'driving',
       annotations: 'distance,duration',
@@ -244,8 +244,8 @@ describe('MatrixTool', () => {
     const tool = new MatrixTool();
     const result = await tool.run({
       coordinates: [
-        [-122.42, 37.78],
-        [-122.45, 37.91]
+        { longitude: -122.42, latitude: 37.78 },
+        { longitude: -122.45, latitude: 37.91 }
       ],
       profile: 'walking'
     });
@@ -263,7 +263,7 @@ describe('MatrixTool', () => {
     const mockFetch = setupFetch();
 
     const tool = new MatrixTool();
-    const coordinates = Array(11).fill([-122.42, 37.78]);
+    const coordinates = Array(11).fill({ longitude: -122.42, latitude: 37.78 });
 
     const result = await tool.run({
       coordinates,
@@ -295,7 +295,7 @@ describe('MatrixTool', () => {
 
     it('validates coordinates - minimum count', async () => {
       const result = await tool.run({
-        coordinates: [[-122.42, 37.78]],
+        coordinates: [{ longitude: -122.42, latitude: 37.78 }],
         profile: 'driving'
       });
 
@@ -304,14 +304,17 @@ describe('MatrixTool', () => {
       // Test direct error message using Zod validation from schema
       await expect(async () => {
         await tool['inputSchema'].parseAsync({
-          coordinates: [[-122.42, 37.78]],
+          coordinates: [{ longitude: -122.42, latitude: 37.78 }],
           profile: 'driving'
         });
       }).rejects.toThrow('At least two coordinate pairs are required.');
     });
 
     it('validates coordinates - maximum count for regular profiles', async () => {
-      const coordinates = Array(26).fill([-122.42, 37.78]);
+      const coordinates = Array(26).fill({
+        longitude: -122.42,
+        latitude: 37.78
+      });
       const result = await tool.run({
         coordinates,
         profile: 'driving'
@@ -333,8 +336,8 @@ describe('MatrixTool', () => {
     it('validates coordinate bounds', async () => {
       const invalidLongitude = await tool.run({
         coordinates: [
-          [-190, 37.78],
-          [-122.45, 37.91]
+          { longitude: -190, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving'
       });
@@ -344,8 +347,8 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['inputSchema'].parseAsync({
           coordinates: [
-            [-190, 37.78],
-            [-122.45, 37.91]
+            { longitude: -190, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 }
           ],
           profile: 'driving'
         });
@@ -353,8 +356,8 @@ describe('MatrixTool', () => {
 
       const invalidLatitude = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 95]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 95 }
         ],
         profile: 'driving'
       });
@@ -364,8 +367,8 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['inputSchema'].parseAsync({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 95]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 95 }
           ],
           profile: 'driving'
         });
@@ -375,9 +378,9 @@ describe('MatrixTool', () => {
     it('validates approaches parameter length', async () => {
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91],
-          [-122.48, 37.73]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 },
+          { longitude: -122.48, latitude: 37.73 }
         ],
         profile: 'driving',
         approaches: 'curb;unrestricted' // Only 2 for 3 coordinates
@@ -389,9 +392,9 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91],
-            [-122.48, 37.73]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 },
+            { longitude: -122.48, latitude: 37.73 }
           ],
           profile: 'driving',
           approaches: 'curb;unrestricted'
@@ -404,8 +407,8 @@ describe('MatrixTool', () => {
     it('validates approaches parameter values', async () => {
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         approaches: 'curb;invalid' // 'invalid' is not allowed
@@ -417,8 +420,8 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 }
           ],
           profile: 'driving',
           approaches: 'curb;invalid'
@@ -431,9 +434,9 @@ describe('MatrixTool', () => {
     it('validates bearings parameter length', async () => {
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91],
-          [-122.48, 37.73]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 },
+          { longitude: -122.48, latitude: 37.73 }
         ],
         profile: 'driving',
         bearings: '45,90;120,45' // Only 2 for 3 coordinates
@@ -445,9 +448,9 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91],
-            [-122.48, 37.73]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 },
+            { longitude: -122.48, latitude: 37.73 }
           ],
           profile: 'driving',
           bearings: '45,90;120,45'
@@ -460,8 +463,8 @@ describe('MatrixTool', () => {
     it('validates bearings parameter format', async () => {
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         bearings: '45,90;invalid'
@@ -473,8 +476,8 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 }
           ],
           profile: 'driving',
           bearings: '45,90;invalid'
@@ -485,8 +488,8 @@ describe('MatrixTool', () => {
     it('validates bearings parameter angle range', async () => {
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         bearings: '400,90;120,45' // 400 is > 360
@@ -498,8 +501,8 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 }
           ],
           profile: 'driving',
           bearings: '400,90;120,45'
@@ -510,8 +513,8 @@ describe('MatrixTool', () => {
     it('validates bearings parameter degrees range', async () => {
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         bearings: '45,200;120,45' // 200 is > 180
@@ -523,8 +526,8 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 }
           ],
           profile: 'driving',
           bearings: '45,200;120,45'
@@ -535,8 +538,8 @@ describe('MatrixTool', () => {
     it('validates sources parameter indices', async () => {
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         sources: '0;2' // 2 is out of bounds
@@ -548,8 +551,8 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 }
           ],
           profile: 'driving',
           sources: '0;2'
@@ -562,8 +565,8 @@ describe('MatrixTool', () => {
     it('validates destinations parameter indices', async () => {
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         destinations: '3' // 3 is out of bounds
@@ -575,8 +578,8 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 }
           ],
           profile: 'driving',
           destinations: '3'
@@ -589,8 +592,8 @@ describe('MatrixTool', () => {
     it('validates destinations parameter index negative', async () => {
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         destinations: '-1'
@@ -602,8 +605,8 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 }
           ],
           profile: 'driving',
           destinations: '-1'
@@ -620,8 +623,8 @@ describe('MatrixTool', () => {
 
       await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         sources: 'all'
@@ -638,8 +641,8 @@ describe('MatrixTool', () => {
 
       await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         destinations: 'all'
@@ -663,9 +666,9 @@ describe('MatrixTool', () => {
       });
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.46, 37.9],
-          [-122.48, 37.73]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.46, latitude: 37.9 },
+          { longitude: -122.48, latitude: 37.73 }
         ],
         profile: 'driving',
         approaches: 'curb;;unrestricted'
@@ -683,9 +686,9 @@ describe('MatrixTool', () => {
 
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.46, 37.9],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.46, latitude: 37.9 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         bearings: '45,90;;120,45'
@@ -703,9 +706,9 @@ describe('MatrixTool', () => {
 
       const resultWithSuccess1 = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91],
-          [-122.48, 37.73]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 },
+          { longitude: -122.48, latitude: 37.73 }
         ],
         profile: 'driving',
         approaches: 'curb;;unrestricted'
@@ -715,8 +718,8 @@ describe('MatrixTool', () => {
 
       const resultWithSuccess2 = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         approaches: 'curb;'
@@ -731,9 +734,9 @@ describe('MatrixTool', () => {
       });
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91],
-          [-122.48, 37.73]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 },
+          { longitude: -122.48, latitude: 37.73 }
         ],
         profile: 'driving',
         sources: '1',
@@ -746,9 +749,9 @@ describe('MatrixTool', () => {
       await expect(async () => {
         await tool['execute']({
           coordinates: [
-            [-122.42, 37.78],
-            [-122.45, 37.91],
-            [-122.48, 37.73]
+            { longitude: -122.42, latitude: 37.78 },
+            { longitude: -122.45, latitude: 37.91 },
+            { longitude: -122.48, latitude: 37.73 }
           ],
           profile: 'driving',
           sources: '1',
@@ -765,8 +768,8 @@ describe('MatrixTool', () => {
       });
       await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         sources: '0',
@@ -783,8 +786,8 @@ describe('MatrixTool', () => {
       });
       await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         annotations: 'duration,distance'
@@ -797,8 +800,8 @@ describe('MatrixTool', () => {
       });
       await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving',
         annotations: 'distance,duration'
@@ -819,9 +822,12 @@ describe('MatrixTool', () => {
       const mockFetch = setupFetch({
         json: () => Promise.resolve(sampleMatrixResponse)
       });
-      const coordinates: [number, number][] = Array.from(
+      const coordinates: { longitude: number; latitude: number }[] = Array.from(
         { length: 25 },
-        (_, i) => [-122.42 + i * 0.01, 37.78 + i * 0.01]
+        (_, i) => ({
+          longitude: -122.42 + i * 0.01,
+          latitude: 37.78 + i * 0.01
+        })
       );
       const result = await tool.run({
         coordinates,
@@ -835,9 +841,12 @@ describe('MatrixTool', () => {
       const mockFetch = setupFetch({
         json: () => Promise.resolve(sampleMatrixResponse)
       });
-      const coordinates: [number, number][] = Array.from(
+      const coordinates: { longitude: number; latitude: number }[] = Array.from(
         { length: 10 },
-        (_, i) => [-122.42 + i * 0.01, 37.78 + i * 0.01]
+        (_, i) => ({
+          longitude: -122.42 + i * 0.01,
+          latitude: 37.78 + i * 0.01
+        })
       );
       const result = await tool.run({
         coordinates,
@@ -849,9 +858,12 @@ describe('MatrixTool', () => {
 
     it('rejects 11 coordinates for driving-traffic profile', async () => {
       const mockFetch = setupFetch();
-      const coordinates: [number, number][] = Array.from(
+      const coordinates: { longitude: number; latitude: number }[] = Array.from(
         { length: 11 },
-        (_, i) => [-122.42 + i * 0.01, 37.78 + i * 0.01]
+        (_, i) => ({
+          longitude: -122.42 + i * 0.01,
+          latitude: 37.78 + i * 0.01
+        })
       );
       const result = await tool.run({
         coordinates,
@@ -887,8 +899,8 @@ describe('MatrixTool', () => {
 
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving-traffic'
       });
@@ -905,8 +917,8 @@ describe('MatrixTool', () => {
 
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'driving'
       });
@@ -923,8 +935,8 @@ describe('MatrixTool', () => {
 
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'walking'
       });
@@ -941,8 +953,8 @@ describe('MatrixTool', () => {
 
       const result = await tool.run({
         coordinates: [
-          [-122.42, 37.78],
-          [-122.45, 37.91]
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.45, latitude: 37.91 }
         ],
         profile: 'cycling'
       });

--- a/src/tools/matrix-tool/MatrixTool.ts
+++ b/src/tools/matrix-tool/MatrixTool.ts
@@ -7,16 +7,16 @@ import { MapboxApiBasedTool } from '../MapboxApiBasedTool.js';
 const MatrixInputSchema = z.object({
   coordinates: z
     .array(
-      z.tuple([
-        z
+      z.object({
+        longitude: z
           .number()
           .min(-180, 'Longitude must be between -180 and 180 degrees')
           .max(180, 'Longitude must be between -180 and 180 degrees'),
-        z
+        latitude: z
           .number()
           .min(-90, 'Latitude must be between -90 and 90 degrees')
           .max(90, 'Latitude must be between -90 and 90 degrees')
-      ])
+      })
     )
     .min(2, 'At least two coordinate pairs are required.')
     .max(
@@ -24,7 +24,7 @@ const MatrixInputSchema = z.object({
       'Up to 25 coordinate pairs are supported for most profiles (10 for driving-traffic).'
     )
     .describe(
-      'Array of [longitude, latitude] coordinate pairs. ' +
+      'Array of coordinate objects with longitude and latitude properties. ' +
         'Must include at least 2 coordinate pairs. ' +
         'Up to 25 coordinates total are supported for most profiles (10 for driving-traffic).'
     ),
@@ -229,7 +229,7 @@ export class MatrixTool extends MapboxApiBasedTool<typeof MatrixInputSchema> {
 
     // Format coordinates for API request
     const joined = input.coordinates
-      .map(([lng, lat]) => `${lng},${lat}`)
+      .map(({ longitude, latitude }) => `${longitude},${latitude}`)
       .join(';');
 
     // Build query parameters

--- a/src/tools/poi-search-tool/PoiSearchTool.test.ts
+++ b/src/tools/poi-search-tool/PoiSearchTool.test.ts
@@ -42,15 +42,20 @@ describe('PoiSearchTool', () => {
       q: 'restaurant',
       language: 'es',
       limit: 5,
-      proximity: [-74.006, 40.7128],
-      bbox: [-74.1, 40.6, -73.9, 40.8],
+      proximity: { longitude: -74.006, latitude: 40.7128 },
+      bbox: {
+        minLongitude: -74.1,
+        minLatitude: 40.6,
+        maxLongitude: -73.9,
+        maxLatitude: 40.8
+      },
       country: ['US', 'CA'],
       types: ['poi', 'address'],
       poi_category: ['restaurant', 'cafe'],
       auto_complete: true,
       eta_type: 'navigation',
       navigation_profile: 'driving',
-      origin: [-74.0, 40.7]
+      origin: { longitude: -74.0, latitude: 40.7 }
     });
 
     const calledUrl = mockFetch.mock.calls[0][0];
@@ -177,7 +182,7 @@ describe('PoiSearchTool', () => {
     await expect(
       tool.run({
         q: 'test',
-        proximity: [-181, 40]
+        proximity: { longitude: -181, latitude: 40 }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -187,7 +192,12 @@ describe('PoiSearchTool', () => {
     await expect(
       tool.run({
         q: 'test',
-        bbox: [-74, -91, -73, 40]
+        bbox: {
+          minLongitude: -74,
+          minLatitude: -91,
+          maxLongitude: -73,
+          maxLatitude: 40
+        }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -271,7 +281,8 @@ describe('PoiSearchTool', () => {
     expect(result.is_error).toBe(false);
     expect(result.content[0].type).toBe('text');
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Starbucks Coffee');
     expect(textContent).toContain('Address: 123 Main St, New York, NY 10001');
     expect(textContent).toContain('Coordinates: 40.7128, -74.006');
@@ -308,7 +319,8 @@ describe('PoiSearchTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Central Park (The Central Park)');
     expect(textContent).toContain('Address: Central Park, New York, NY');
     expect(textContent).toContain('Coordinates: 40.782, -73.965');
@@ -356,7 +368,8 @@ describe('PoiSearchTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Starbucks #1');
     expect(textContent).toContain('2. Starbucks #2');
     expect(textContent).toContain('123 Main St, New York, NY 10001');
@@ -379,7 +392,9 @@ describe('PoiSearchTool', () => {
 
     expect(result.is_error).toBe(false);
     expect(result.content[0].type).toBe('text');
-    expect((result.content[0] as { type: 'text'; text: string }).text).toBe('No results found.');
+    expect((result.content[0] as { type: 'text'; text: string }).text).toBe(
+      'No results found.'
+    );
   });
 
   it('handles results with minimal properties', async () => {
@@ -409,7 +424,8 @@ describe('PoiSearchTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Some Location');
     expect(textContent).toContain('Coordinates: 40.7128, -74.006');
     expect(textContent).not.toContain('Address:');

--- a/src/tools/poi-search-tool/PoiSearchTool.test.ts
+++ b/src/tools/poi-search-tool/PoiSearchTool.test.ts
@@ -109,6 +109,18 @@ describe('PoiSearchTool', () => {
     expect(calledUrl).toContain('proximity=-82.451668%2C27.942964');
   });
 
+  it('handles JSON-stringified object format proximity', async () => {
+    const mockFetch = setupFetch();
+
+    await new PoiSearchTool().run({
+      q: 'restaurant',
+      proximity: '{"longitude": -82.458107, "latitude": 27.937259}'
+    });
+
+    const calledUrl = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('proximity=-82.458107%2C27.937259');
+  });
+
   it('uses default limit when not specified', async () => {
     const mockFetch = setupFetch();
 

--- a/src/tools/poi-search-tool/PoiSearchTool.ts
+++ b/src/tools/poi-search-tool/PoiSearchTool.ts
@@ -21,7 +21,10 @@ const PoiSearchInputSchema = z.object({
     .describe('Maximum number of results to return (1-10)'),
   proximity: z
     .union([
-      z.tuple([z.number().min(-180).max(180), z.number().min(-90).max(90)]),
+      z.object({
+        longitude: z.number().min(-180).max(180),
+        latitude: z.number().min(-90).max(90)
+      }),
       z.string().transform((val) => {
         // Handle special case of 'ip'
         if (val === 'ip') {
@@ -34,34 +37,32 @@ const PoiSearchInputSchema = z.object({
             .split(',')
             .map((s) => Number(s.trim()));
           if (coords.length === 2 && !isNaN(coords[0]) && !isNaN(coords[1])) {
-            return coords as [number, number];
+            return { longitude: coords[0], latitude: coords[1] };
           }
         }
         // Handle comma-separated string: "-82.451668,27.942964"
         const parts = val.split(',').map((s) => Number(s.trim()));
         if (parts.length === 2 && !isNaN(parts[0]) && !isNaN(parts[1])) {
-          return parts as [number, number];
+          return { longitude: parts[0], latitude: parts[1] };
         }
         throw new Error(
-          'Invalid proximity format. Expected [longitude, latitude], "longitude,latitude", or "ip"'
+          'Invalid proximity format. Expected {longitude, latitude}, "longitude,latitude", or "ip"'
         );
       })
     ])
     .optional()
     .describe(
-      'Location to bias results towards. Either [longitude, latitude] or "ip" for IP-based location. STRONGLY ENCOURAGED for relevant results.'
+      'Location to bias results towards. Either coordinate object with longitude and latitude or "ip" for IP-based location. STRONGLY ENCOURAGED for relevant results.'
     ),
   bbox: z
-    .tuple([
-      z.number().min(-180).max(180),
-      z.number().min(-90).max(90),
-      z.number().min(-180).max(180),
-      z.number().min(-90).max(90)
-    ])
+    .object({
+      minLongitude: z.number().min(-180).max(180),
+      minLatitude: z.number().min(-90).max(90),
+      maxLongitude: z.number().min(-180).max(180),
+      maxLatitude: z.number().min(-90).max(90)
+    })
     .optional()
-    .describe(
-      'Bounding box to limit results within [minLon, minLat, maxLon, maxLat]'
-    ),
+    .describe('Bounding box to limit results within specified bounds'),
   country: z
     .array(z.string().length(2))
     .optional()
@@ -91,9 +92,14 @@ const PoiSearchInputSchema = z.object({
     .optional()
     .describe('Routing profile for ETA calculations'),
   origin: z
-    .tuple([z.number().min(-180).max(180), z.number().min(-90).max(90)])
+    .object({
+      longitude: z.number().min(-180).max(180),
+      latitude: z.number().min(-90).max(90)
+    })
     .optional()
-    .describe('Starting point for ETA calculations as [longitude, latitude]')
+    .describe(
+      'Starting point for ETA calculations as coordinate object with longitude and latitude'
+    )
 });
 
 export class PoiSearchTool extends MapboxApiBasedTool<
@@ -193,16 +199,17 @@ export class PoiSearchTool extends MapboxApiBasedTool<
       if (input.proximity === 'ip') {
         url.searchParams.append('proximity', 'ip');
       } else {
-        const [lng, lat] = input.proximity;
-        url.searchParams.append('proximity', `${lng},${lat}`);
+        const { longitude, latitude } = input.proximity;
+        url.searchParams.append('proximity', `${longitude},${latitude}`);
       }
     }
 
     if (input.bbox) {
-      const [minLon, minLat, maxLon, maxLat] = input.bbox;
+      const { minLongitude, minLatitude, maxLongitude, maxLatitude } =
+        input.bbox;
       url.searchParams.append(
         'bbox',
-        `${minLon},${minLat},${maxLon},${maxLat}`
+        `${minLongitude},${minLatitude},${maxLongitude},${maxLatitude}`
       );
     }
 
@@ -231,8 +238,8 @@ export class PoiSearchTool extends MapboxApiBasedTool<
     }
 
     if (input.origin) {
-      const [lng, lat] = input.origin;
-      url.searchParams.append('origin', `${lng},${lat}`);
+      const { longitude, latitude } = input.origin;
+      url.searchParams.append('origin', `${longitude},${latitude}`);
     }
 
     this.log(

--- a/src/tools/poi-search-tool/PoiSearchTool.ts
+++ b/src/tools/poi-search-tool/PoiSearchTool.ts
@@ -30,6 +30,22 @@ const PoiSearchInputSchema = z.object({
         if (val === 'ip') {
           return 'ip' as const;
         }
+        // Handle JSON-stringified object: "{\"longitude\": -82.458107, \"latitude\": 27.937259}"
+        if (val.startsWith('{') && val.endsWith('}')) {
+          try {
+            const parsed = JSON.parse(val);
+            if (
+              typeof parsed === 'object' &&
+              parsed !== null &&
+              typeof parsed.longitude === 'number' &&
+              typeof parsed.latitude === 'number'
+            ) {
+              return { longitude: parsed.longitude, latitude: parsed.latitude };
+            }
+          } catch {
+            // Fall back to other formats
+          }
+        }
         // Handle string that looks like an array: "[-82.451668, 27.942964]"
         if (val.startsWith('[') && val.endsWith(']')) {
           const coords = val

--- a/src/tools/static-map-image-tool/StaticMapImageTool.test.ts
+++ b/src/tools/static-map-image-tool/StaticMapImageTool.test.ts
@@ -15,9 +15,9 @@ describe('StaticMapImageTool', () => {
     const mockFetch = setupFetch();
 
     await new StaticMapImageTool().run({
-      center: [-74.006, 40.7128],
+      center: { longitude: -74.006, latitude: 40.7128 },
       zoom: 12,
-      size: [600, 400],
+      size: { width: 600, height: 400 },
       style: 'mapbox/streets-v12'
     });
 
@@ -37,9 +37,9 @@ describe('StaticMapImageTool', () => {
     });
 
     const result = await new StaticMapImageTool().run({
-      center: [-74.006, 40.7128],
+      center: { longitude: -74.006, latitude: 40.7128 },
       zoom: 10,
-      size: [800, 600],
+      size: { width: 800, height: 600 },
       style: 'mapbox/satellite-v9'
     });
 
@@ -56,9 +56,9 @@ describe('StaticMapImageTool', () => {
     const mockFetch = setupFetch();
 
     await new StaticMapImageTool().run({
-      center: [-122.4194, 37.7749],
+      center: { longitude: -122.4194, latitude: 37.7749 },
       zoom: 15,
-      size: [1024, 768],
+      size: { width: 1024, height: 768 },
       style: 'mapbox/dark-v10'
     });
 
@@ -73,9 +73,9 @@ describe('StaticMapImageTool', () => {
     const mockFetch = setupFetch();
 
     await new StaticMapImageTool().run({
-      center: [0, 0],
+      center: { longitude: 0, latitude: 0 },
       zoom: 1,
-      size: [300, 200]
+      size: { width: 300, height: 200 }
     });
 
     const calledUrl = mockFetch.mock.calls[0][0];
@@ -90,9 +90,9 @@ describe('StaticMapImageTool', () => {
     });
 
     const result = await new StaticMapImageTool().run({
-      center: [-74.006, 40.7128],
+      center: { longitude: -74.006, latitude: 40.7128 },
       zoom: 12,
-      size: [600, 400]
+      size: { width: 600, height: 400 }
     });
 
     expect(result.is_error).toBe(true);
@@ -108,9 +108,9 @@ describe('StaticMapImageTool', () => {
     // Test invalid longitude
     await expect(
       tool.run({
-        center: [-181, 40],
+        center: { longitude: -181, latitude: 40 },
         zoom: 10,
-        size: [600, 400]
+        size: { width: 600, height: 400 }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -119,9 +119,9 @@ describe('StaticMapImageTool', () => {
     // Test invalid latitude
     await expect(
       tool.run({
-        center: [-74, 90],
+        center: { longitude: -74, latitude: 90 },
         zoom: 10,
-        size: [600, 400]
+        size: { width: 600, height: 400 }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -134,9 +134,9 @@ describe('StaticMapImageTool', () => {
     // Test size too large
     await expect(
       tool.run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 10,
-        size: [1281, 600]
+        size: { width: 1281, height: 600 }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -145,9 +145,9 @@ describe('StaticMapImageTool', () => {
     // Test size too small
     await expect(
       tool.run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 10,
-        size: [0, 600]
+        size: { width: 0, height: 600 }
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -158,9 +158,9 @@ describe('StaticMapImageTool', () => {
     const mockFetch = setupFetch();
 
     await new StaticMapImageTool().run({
-      center: [-74.006, 40.7128],
+      center: { longitude: -74.006, latitude: 40.7128 },
       zoom: 12,
-      size: [600, 400],
+      size: { width: 600, height: 400 },
       highDensity: true
     });
 
@@ -173,9 +173,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'marker',
@@ -196,9 +196,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'custom-marker',
@@ -219,9 +219,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'path',
@@ -250,9 +250,9 @@ describe('StaticMapImageTool', () => {
       };
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'geojson',
@@ -271,9 +271,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'marker',
@@ -303,9 +303,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400]
+        size: { width: 600, height: 400 }
       });
 
       const calledUrl = mockFetch.mock.calls[0][0];
@@ -317,9 +317,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'marker',
@@ -341,9 +341,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'marker',
@@ -364,9 +364,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'marker',
@@ -388,9 +388,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'marker',
@@ -411,9 +411,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-80.278, 25.796],
+        center: { longitude: -80.278, latitude: 25.796 },
         zoom: 15,
-        size: [800, 600],
+        size: { width: 800, height: 600 },
         style: 'mapbox/streets-v12',
         overlays: [
           {
@@ -460,9 +460,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'marker',
@@ -493,9 +493,9 @@ describe('StaticMapImageTool', () => {
       const mockFetch = setupFetch();
 
       await new StaticMapImageTool().run({
-        center: [-74.006, 40.7128],
+        center: { longitude: -74.006, latitude: 40.7128 },
         zoom: 12,
-        size: [600, 400],
+        size: { width: 600, height: 400 },
         overlays: [
           {
             type: 'marker',

--- a/src/tools/static-map-image-tool/StaticMapImageTool.ts
+++ b/src/tools/static-map-image-tool/StaticMapImageTool.ts
@@ -313,12 +313,12 @@ const OverlaySchema = z.discriminatedUnion('type', [
 
 const StaticMapImageInputSchema = z.object({
   center: z
-    .tuple([
-      z.number().min(-180).max(180),
-      z.number().min(-85.0511).max(85.0511)
-    ])
+    .object({
+      longitude: z.number().min(-180).max(180),
+      latitude: z.number().min(-85.0511).max(85.0511)
+    })
     .describe(
-      'Center point of the map as [longitude, latitude]. Longitude: -180 to 180, Latitude: -85.0511 to 85.0511'
+      'Center point of the map as coordinate object with longitude and latitude properties. Longitude: -180 to 180, Latitude: -85.0511 to 85.0511'
     ),
   zoom: z
     .number()
@@ -328,9 +328,12 @@ const StaticMapImageInputSchema = z.object({
       'Zoom level (0-22). Fractional zoom levels are rounded to two decimal places'
     ),
   size: z
-    .tuple([z.number().min(1).max(1280), z.number().min(1).max(1280)])
+    .object({
+      width: z.number().min(1).max(1280),
+      height: z.number().min(1).max(1280)
+    })
     .describe(
-      'Image size as [width, height] in pixels. Each dimension must be between 1 and 1280 pixels'
+      'Image size as object with width and height properties in pixels. Each dimension must be between 1 and 1280 pixels'
     ),
   style: z
     .string()
@@ -416,8 +419,8 @@ export class StaticMapImageTool extends MapboxApiBasedTool<
   protected async execute(
     input: z.infer<typeof StaticMapImageInputSchema>
   ): Promise<any> {
-    const [lng, lat] = input.center;
-    const [width, height] = input.size;
+    const { longitude: lng, latitude: lat } = input.center;
+    const { width, height } = input.size;
 
     // Build overlay string
     let overlayString = '';


### PR DESCRIPTION
## Description

<!-- Provide a clear explanation of what has been implemented or fixed. Mention any related context, requirements, or issues. -->

Use object instead of tuple on tool input. It worked in Claude Desktop w/ tuples, but other clients/libraries expect object.  

---

## Testing

<!-- Include logs, screenshots, terminal output, or any relevant proof of successful testing. -->

- I tested all of the tools in Claude Desktop
- I also testing using a script that uses langchain-mcp-adapter with OpenAI gpt 4.1 and Anthropic's claude opus. 
- I tested using the script in docs/using-mcp-with-smolagents

---

## Checklist

- [x] Code has been tested locally
- [x] Unit tests have been added or updated
- [x] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
