### PR TITLE
Small improvements to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For detailed setup instructions for different integrations, refer to the followi
 
 - [Claude Desktop Setup](./docs/claude-desktop-setup.md) - Instructions for configuring Claude Desktop to work with this MCP server
 - [VS Code Setup](./docs/vscode-setup.md) - Setting up a development environment in Visual Studio Code
-- [SmolaGents Integration](./docs/using-mcp-with-smolagents/README.md) - Example showing how to connect SmolaGents AI agents to Mapbox's tools
+- [Smolagents Integration](./docs/using-mcp-with-smolagents/README.md) - Example showing how to connect Smolagents AI agents to Mapbox's tools
 
 ## Tools
 

--- a/docs/claude-desktop-setup.md
+++ b/docs/claude-desktop-setup.md
@@ -12,6 +12,9 @@ This guide explains how to set up and configure Claude Desktop for use with the 
 # using node
 npm run build
 
+# note your absolute path to node, you will need it for MCP config
+where node
+
 # or alternatively, using docker
 docker build -t mapbox-mcp-server .
 ```
@@ -34,7 +37,7 @@ docker build -t mapbox-mcp-server .
 {
   "mcpServers": {
     "MapboxServer": {
-      "command": "node",
+      "command": "/Users/username/.nvm/versions/node/v22.3.0/bin/node",
       "args": ["YOUR_PATH_TO_GIT_REPOSITORY/dist/index.js"],
       "env": {
         "MAPBOX_ACCESS_TOKEN": "YOUR_TOKEN"

--- a/docs/using-mcp-with-smolagents/README.md
+++ b/docs/using-mcp-with-smolagents/README.md
@@ -1,6 +1,6 @@
-# Using SmolaGents with Mapbox MCP
+# Using Smolagents with Mapbox MCP
 
-This example demonstrates how to integrate Mapbox's Model Context Protocol (MCP) server with SmolaGents, allowing AI agents to access Mapbox's location-based tools.
+This example demonstrates how to integrate Mapbox's Model Context Protocol (MCP) server with Smolagents, allowing AI agents to access Mapbox's location-based tools.
 
 ## Overview
 
@@ -77,7 +77,7 @@ agent.run("Your location-based question here")
 
 For more information about:
 
-- SmolaGents: [SmolaGents Documentation](https://github.com/smol-ai/smolagents)
+- Smolagents: [Smolagents Documentation](https://github.com/smol-ai/smolagents)
 - Mapbox MCP: See the [main repository documentation](../../README.md)
 - Additional setup guides:
   - [Claude Desktop Setup](../claude-desktop-setup.md)

--- a/docs/using-mcp-with-smolagents/README.md
+++ b/docs/using-mcp-with-smolagents/README.md
@@ -23,6 +23,9 @@ The `smolagents_example.py` script shows a simple but powerful implementation of
 # Build node (from repository root)
 npm run build
 
+# note your absolute path to node, you will need it for MCP config
+where node
+
 # Alternatively, build docker
 docker build -t mapbox-mcp-server .
 ```
@@ -47,10 +50,11 @@ It connects to the Mapbox MCP server, which exposes Mapbox's functionality as to
    export MAPBOX_ACCESS_TOKEN=your_token_here
    ```
 
-2. Update the path to the MCP server in the script:
+2. Update the path to your node and the MCP server in the script:
 
    ```python
-   args=["/path/to/your/repository/dist/index.js"]
+   command="/Users/username/.nvm/versions/node/v22.3.0/bin/node",
+   args=["/YOUR_PATH_TO_REPOSITORY/dist/index.js"],
    ```
 
 3. Choose your preferred model by setting the `chosen_inference` variable

--- a/docs/using-mcp-with-smolagents/smolagents_example.py
+++ b/docs/using-mcp-with-smolagents/smolagents_example.py
@@ -49,7 +49,7 @@ if os.environ.get("MAPBOX_ACCESS_TOKEN", None) is None:
 # Run server with node
 # alternatively you can use command="docker" and args=["run", "-i", "--rm", "mapbox-mcp-server"] 
 server_parameters = StdioServerParameters(
-    command="node",
+    command="/Users/username/.nvm/versions/node/v22.3.0/bin/node",
     args=["/YOUR_PATH_TO_REPOSITORY/dist/index.js"],
     env={"MAPBOX_ACCESS_TOKEN": os.environ["MAPBOX_ACCESS_TOKEN"]},
 )

--- a/docs/vscode-setup.md
+++ b/docs/vscode-setup.md
@@ -12,6 +12,9 @@ This guide explains how to configure VS Code for use with the Mapbox MCP Server.
 # using node
 npm run build
 
+# note your absolute path to node, you will need it for MCP config
+where node
+
 # or alternatively, using docker
 docker build -t mapbox-mcp-server .
 ```
@@ -42,7 +45,7 @@ docker build -t mapbox-mcp-server .
 
             "mapbox-node": {
                 "type": "stdio",
-                "command": "node",
+                "command": "/Users/username/.nvm/versions/node/v22.3.0/bin/node",
                 "args": [
                     "/YOUR_PATH_TO_GIT_REPOSITORY/dist/index.js"
                 ],


### PR DESCRIPTION
## Description

- Smolagents was capitalised as SmolaGents, which I think was just a typo
- Some users reported `node` command not working to start up MCP, turns out clients might refer to wrong `node` if you have multiple of them. Fix for this is just to specify full path to node in command.

---

## Testing

Tested with Claude desktop, mcp inspector, smolagents script and fix worked for users that reported this problem to me privately. 

---

## Checklist

- [x] Code has been tested locally
- [ ] ~Unit tests have been added or updated~
- [x] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
