### PR TITLE
Verbose errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ npx plop create-tool
 # provide tool name without suffix (e.g. Search)
 ```
 
+## Environment Variables
+
+### VERBOSE_ERRORS
+
+Set `VERBOSE_ERRORS=true` to get detailed error messages from the MCP server. This is useful for debugging issues when integrating with MCP clients.
+
+By default, the server returns generic error messages. With verbose errors enabled, you'll receive the actual error details, which can help diagnose API connection issues, invalid parameters, or other problems.
+
 ---
 
 [License](LICENSE.md)

--- a/docs/claude-desktop-setup.md
+++ b/docs/claude-desktop-setup.md
@@ -13,6 +13,9 @@ This guide explains how to set up and configure Claude Desktop for use with the 
 npm run build
 
 # note your absolute path to node, you will need it for MCP config
+# For Mac/Linux
+which node
+# For Windows
 where node
 
 # or alternatively, using docker

--- a/docs/using-mcp-with-smolagents/README.md
+++ b/docs/using-mcp-with-smolagents/README.md
@@ -24,6 +24,9 @@ The `smolagents_example.py` script shows a simple but powerful implementation of
 npm run build
 
 # note your absolute path to node, you will need it for MCP config
+# For Mac/Linux
+which node
+# For Windows
 where node
 
 # Alternatively, build docker

--- a/docs/vscode-setup.md
+++ b/docs/vscode-setup.md
@@ -13,6 +13,9 @@ This guide explains how to configure VS Code for use with the Mapbox MCP Server.
 npm run build
 
 # note your absolute path to node, you will need it for MCP config
+# For Mac/Linux
+which node
+# For Windows
 where node
 
 # or alternatively, using docker

--- a/src/tools/MapboxApiBasedTool.test.ts
+++ b/src/tools/MapboxApiBasedTool.test.ts
@@ -1,0 +1,131 @@
+process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+
+import { z } from 'zod';
+import { MapboxApiBasedTool } from './MapboxApiBasedTool';
+
+// Create a minimal implementation of MapboxApiBasedTool for testing
+class TestTool extends MapboxApiBasedTool<typeof TestTool.inputSchema> {
+  readonly name = 'test-tool';
+  readonly description = 'Tool for testing MapboxApiBasedTool error handling';
+
+  static readonly inputSchema = z.object({
+    testParam: z.string()
+  });
+
+  constructor() {
+    super({ inputSchema: TestTool.inputSchema });
+  }
+
+  protected async execute(
+    _input: z.infer<typeof TestTool.inputSchema>
+  ): Promise<any> {
+    throw new Error('Test error message');
+  }
+}
+
+describe('MapboxApiBasedTool', () => {
+  let testTool: TestTool;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    testTool = new TestTool();
+    // Mock the log method to test that errors are properly logged
+    testTool['log'] = jest.fn();
+  });
+
+  afterEach(() => {
+    // Restore the process.env to its original state
+    process.env = { ...originalEnv };
+    jest.clearAllMocks();
+  });
+
+  describe('error handling', () => {
+    it('returns generic error message when VERBOSE_ERRORS is not set to true', async () => {
+      // Make sure VERBOSE_ERRORS is not set to true
+      delete process.env.VERBOSE_ERRORS;
+
+      const result = await testTool.run({ testParam: 'test' });
+
+      // Verify the response contains the generic error message
+      expect(result.is_error).toBe(true);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toMatchObject({
+        type: 'text',
+        text: 'Internal error has occurred.'
+      });
+
+      // Verify the error was logged with the actual error message
+      expect(testTool['log']).toHaveBeenCalledWith(
+        'error',
+        expect.stringContaining('Test error message')
+      );
+    });
+
+    it('returns actual error message when VERBOSE_ERRORS=true', async () => {
+      // Set VERBOSE_ERRORS to true
+      process.env.VERBOSE_ERRORS = 'true';
+
+      const result = await testTool.run({ testParam: 'test' });
+
+      // Verify the response contains the actual error message
+      expect(result.is_error).toBe(true);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toMatchObject({
+        type: 'text',
+        text: 'Test error message'
+      });
+
+      // Verify the error was logged with the actual error message
+      expect(testTool['log']).toHaveBeenCalledWith(
+        'error',
+        expect.stringContaining('Test error message')
+      );
+    });
+
+    it('returns generic error message when VERBOSE_ERRORS is set to a value other than true', async () => {
+      // Set VERBOSE_ERRORS to something other than 'true'
+      process.env.VERBOSE_ERRORS = 'yes';
+
+      const result = await testTool.run({ testParam: 'test' });
+
+      // Verify the response contains the generic error message
+      expect(result.is_error).toBe(true);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toMatchObject({
+        type: 'text',
+        text: 'Internal error has occurred.'
+      });
+
+      // Verify the error was logged with the actual error message
+      expect(testTool['log']).toHaveBeenCalledWith(
+        'error',
+        expect.stringContaining('Test error message')
+      );
+    });
+
+    it('handles non-Error objects thrown', async () => {
+      // Override the execute method to throw a string instead of an Error
+      testTool['execute'] = jest.fn().mockImplementation(() => {
+        throw 'String error message';
+      });
+
+      process.env.VERBOSE_ERRORS = 'true';
+
+      const result = await testTool.run({ testParam: 'test' });
+
+      // Verify the response contains the string error
+      expect(result.is_error).toBe(true);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toMatchObject({
+        type: 'text',
+        text: 'String error message'
+      });
+
+      // Verify the error was logged
+      expect(testTool['log']).toHaveBeenCalledWith(
+        'error',
+        expect.stringContaining('String error message')
+      );
+    });
+  });
+});

--- a/src/tools/MapboxApiBasedTool.test.ts
+++ b/src/tools/MapboxApiBasedTool.test.ts
@@ -1,4 +1,6 @@
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+// Use a token with valid JWT format for tests
+process.env.MAPBOX_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
 
 import { z } from 'zod';
 import { MapboxApiBasedTool } from './MapboxApiBasedTool';
@@ -37,6 +39,71 @@ describe('MapboxApiBasedTool', () => {
     // Restore the process.env to its original state
     process.env = { ...originalEnv };
     jest.clearAllMocks();
+  });
+
+  describe('JWT token validation', () => {
+    it('throws an error when the token is not in a valid JWT format', async () => {
+      // Test the private isValidJwtFormat method directly
+      const originalToken = MapboxApiBasedTool.MAPBOX_ACCESS_TOKEN;
+
+      try {
+        // Temporarily modify the static property for testing
+        Object.defineProperty(MapboxApiBasedTool, 'MAPBOX_ACCESS_TOKEN', {
+          value: 'invalid-token-format',
+          writable: true,
+          configurable: true
+        });
+
+        // Create a new instance with the modified token
+        const toolWithInvalidToken = new TestTool();
+        // Mock the log method separately for this instance
+        toolWithInvalidToken['log'] = jest.fn();
+
+        // Try to call the run method, it should throw an error due to invalid JWT format
+        const result = await toolWithInvalidToken.run({ testParam: 'test' });
+
+        // Verify the error response
+        expect(result.is_error).toBe(true);
+
+        // Check for error message content
+        if (process.env.VERBOSE_ERRORS === 'true') {
+          expect(
+            (result.content[0] as { type: 'text'; text: string }).text
+          ).toContain('not in valid JWT format');
+        }
+
+        // Verify the error was logged
+        expect(toolWithInvalidToken['log']).toHaveBeenCalledWith(
+          'error',
+          expect.stringMatching(/.*not in valid JWT format.*/)
+        );
+      } finally {
+        // Restore the original value
+        Object.defineProperty(MapboxApiBasedTool, 'MAPBOX_ACCESS_TOKEN', {
+          value: originalToken,
+          writable: true,
+          configurable: true
+        });
+      }
+    });
+
+    it('accepts a token with valid JWT format', async () => {
+      // Set a valid JWT format token (header.payload.signature)
+      process.env.MAPBOX_ACCESS_TOKEN =
+        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
+
+      // Override execute to return a success result instead of throwing an error
+      testTool['execute'] = jest.fn().mockResolvedValue({ success: true });
+
+      const result = await testTool.run({ testParam: 'test' });
+
+      // The token validation should pass, and we should get the success result
+      expect(result.is_error).toBe(false);
+      expect(result.content[0]).toHaveProperty('type', 'text');
+      expect(
+        JSON.parse((result.content[0] as { type: 'text'; text: string }).text)
+      ).toEqual({ success: true });
+    });
   });
 
   describe('error handling', () => {

--- a/src/tools/MapboxApiBasedTool.ts
+++ b/src/tools/MapboxApiBasedTool.ts
@@ -37,12 +37,32 @@ export abstract class MapboxApiBasedTool<InputSchema extends ZodTypeAny> {
   }
 
   /**
+   * Validates if a string has the format of a JWT token (header.payload.signature)
+   * Docs: https://docs.mapbox.com/api/accounts/tokens/#token-format
+   * @param token The token string to validate
+   * @returns boolean indicating if the token has valid JWT format
+   */
+  private isValidJwtFormat(token: string): boolean {
+    // JWT consists of three parts separated by dots: header.payload.signature
+    const parts = token.split('.');
+    if (parts.length !== 3) return false;
+
+    // Check that all parts are non-empty
+    return parts.every((part) => part.length > 0);
+  }
+
+  /**
    * Validates and runs the tool logic.
    */
   async run(rawInput: unknown): Promise<z.infer<typeof OutputSchema>> {
     try {
       if (!MapboxApiBasedTool.MAPBOX_ACCESS_TOKEN) {
         throw new Error('MAPBOX_ACCESS_TOKEN is not set');
+      }
+
+      // Validate that the token has the correct JWT format
+      if (!this.isValidJwtFormat(MapboxApiBasedTool.MAPBOX_ACCESS_TOKEN)) {
+        throw new Error('MAPBOX_ACCESS_TOKEN is not in valid JWT format');
       }
 
       const input = this.inputSchema.parse(rawInput);

--- a/src/tools/MapboxApiBasedTool.ts
+++ b/src/tools/MapboxApiBasedTool.ts
@@ -66,15 +66,23 @@ export abstract class MapboxApiBasedTool<InputSchema extends ZodTypeAny> {
         is_error: false
       };
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
       this.log(
         'error',
-        `${this.name}: Error during execution: ${error instanceof Error ? error.message : String(error)}`
+        `${this.name}: Error during execution: ${errorMessage}`
       );
+
+      const isVerboseErrors = process.env.VERBOSE_ERRORS === 'true';
+
       return {
         content: [
           {
             type: 'text',
-            text: 'Internal error has occurred.'
+            text: isVerboseErrors
+              ? errorMessage
+              : 'Internal error has occurred.'
           }
         ],
         is_error: true

--- a/src/tools/category-search-tool/CategorySearchTool.test.ts
+++ b/src/tools/category-search-tool/CategorySearchTool.test.ts
@@ -1,5 +1,6 @@
 // Set the token before importing the tool
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+process.env.MAPBOX_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
 
 import {
   setupFetch,

--- a/src/tools/directions-tool/DirectionsTool.test.ts
+++ b/src/tools/directions-tool/DirectionsTool.test.ts
@@ -1,4 +1,5 @@
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+process.env.MAPBOX_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
 
 import { cleanup } from '../../utils/requestUtils.js';
 import {

--- a/src/tools/forward-geocode-tool/ForwardGeocodeTool.test.ts
+++ b/src/tools/forward-geocode-tool/ForwardGeocodeTool.test.ts
@@ -1,5 +1,6 @@
 // Set the token before importing the tool
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+process.env.MAPBOX_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
 
 import {
   setupFetch,

--- a/src/tools/isochrone-tool/IsochroneTool.test.ts
+++ b/src/tools/isochrone-tool/IsochroneTool.test.ts
@@ -1,4 +1,5 @@
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+process.env.MAPBOX_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
 
 import { cleanup } from '../../utils/requestUtils.js';
 import {

--- a/src/tools/matrix-tool/MatrixTool.test.ts
+++ b/src/tools/matrix-tool/MatrixTool.test.ts
@@ -1,4 +1,5 @@
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+process.env.MAPBOX_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
 
 import { cleanup } from '../../utils/requestUtils.js';
 import {
@@ -102,7 +103,9 @@ describe('MatrixTool', () => {
     expect(url).toContain(
       'directions-matrix/v1/mapbox/driving/-122.42,37.78;-122.45,37.91;-122.48,37.73'
     );
-    expect(url).toContain('access_token=test-token');
+    expect(url).toContain(
+      'access_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature'
+    );
 
     assertHeadersSent(mockFetch);
   });

--- a/src/tools/poi-search-tool/PoiSearchTool.test.ts
+++ b/src/tools/poi-search-tool/PoiSearchTool.test.ts
@@ -1,5 +1,6 @@
 // Set the token before importing the tool
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+process.env.MAPBOX_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
 
 import {
   setupFetch,

--- a/src/tools/reverse-geocode-tool/ReverseGeocodeTool.test.ts
+++ b/src/tools/reverse-geocode-tool/ReverseGeocodeTool.test.ts
@@ -1,5 +1,6 @@
 // Set the token before importing the tool
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+process.env.MAPBOX_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
 
 import {
   setupFetch,
@@ -268,9 +269,12 @@ describe('ReverseGeocodeTool', () => {
     expect(result.is_error).toBe(false);
     expect(result.content[0].type).toBe('text');
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. 123 Main Street');
-    expect(textContent).toContain('Address: 123 Main Street, New York, NY 10001, United States');
+    expect(textContent).toContain(
+      'Address: 123 Main Street, New York, NY 10001, United States'
+    );
     expect(textContent).toContain('Coordinates: 40.733, -73.989');
     expect(textContent).toContain('Type: address');
   });
@@ -305,9 +309,12 @@ describe('ReverseGeocodeTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Manhattan (Manhattan Borough)');
-    expect(textContent).toContain('Address: Manhattan, New York, NY, United States');
+    expect(textContent).toContain(
+      'Address: Manhattan, New York, NY, United States'
+    );
     expect(textContent).toContain('Coordinates: 40.776, -73.971');
   });
 
@@ -324,7 +331,7 @@ describe('ReverseGeocodeTool', () => {
           },
           geometry: {
             type: 'Point',
-            coordinates: [-73.990, 40.694]
+            coordinates: [-73.99, 40.694]
           }
         },
         {
@@ -347,7 +354,7 @@ describe('ReverseGeocodeTool', () => {
     });
 
     const result = await new ReverseGeocodeTool().run({
-      longitude: -73.990,
+      longitude: -73.99,
       latitude: 40.694,
       limit: 2,
       types: ['address']
@@ -355,11 +362,16 @@ describe('ReverseGeocodeTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. 456 Oak Street');
     expect(textContent).toContain('2. 458 Oak Street');
-    expect(textContent).toContain('456 Oak Street, Brooklyn, NY 11201, United States');
-    expect(textContent).toContain('458 Oak Street, Brooklyn, NY 11201, United States');
+    expect(textContent).toContain(
+      '456 Oak Street, Brooklyn, NY 11201, United States'
+    );
+    expect(textContent).toContain(
+      '458 Oak Street, Brooklyn, NY 11201, United States'
+    );
   });
 
   it('handles empty results gracefully', async () => {
@@ -379,7 +391,9 @@ describe('ReverseGeocodeTool', () => {
 
     expect(result.is_error).toBe(false);
     expect(result.content[0].type).toBe('text');
-    expect((result.content[0] as { type: 'text'; text: string }).text).toBe('No results found.');
+    expect((result.content[0] as { type: 'text'; text: string }).text).toBe(
+      'No results found.'
+    );
   });
 
   it('handles results with minimal properties', async () => {
@@ -410,7 +424,8 @@ describe('ReverseGeocodeTool', () => {
 
     expect(result.is_error).toBe(false);
 
-    const textContent = (result.content[0] as { type: 'text'; text: string }).text;
+    const textContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
     expect(textContent).toContain('1. Some Location');
     expect(textContent).toContain('Coordinates: 35.456, -100.123');
     expect(textContent).not.toContain('Address:');

--- a/src/tools/static-map-image-tool/StaticMapImageTool.test.ts
+++ b/src/tools/static-map-image-tool/StaticMapImageTool.test.ts
@@ -1,4 +1,5 @@
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+process.env.MAPBOX_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
 
 import {
   setupFetch,


### PR DESCRIPTION
## Description

I've got some feedback that errors are generic and not helpful.

I am not sure if it's worth exposing all the errors right now, maybe this could negative affect agents by throwing unnecessary context at them.

However, I've added in this pr:
- a flag to make errors verbose, it's not set by default, but it can be used to get more information.
- checking if Mapbox API token is not valid format, and throwing error with explicit message, this should help with silly mistakes in config.

---

## Testing

### Confirming that tokens in bad format receive explicit error:
<img width="754" alt="image" src="https://github.com/user-attachments/assets/2a985260-4182-4e0c-8add-7d9402a565d7" />

---

### Confirming that entirely missing token will cause it's own error still (it's not a new behaviour, just making sure I did not break it)
<img width="802" alt="image" src="https://github.com/user-attachments/assets/4dde0dec-4aa7-47ef-ae19-4053b57f4c7d" />

---

### Confirming verbose flag makes errors more informative:
<img width="763" alt="image" src="https://github.com/user-attachments/assets/e746824b-58de-43fd-998c-ea45f259edb9" />



## Checklist

- [x] Code has been tested locally
- [x] Unit tests have been added or updated
- [x] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
