### PR TITLE
Add format parameter to all geocoding and search tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.2.0 (2025-06-25)
+
+- **Format Options**: Add `format` parameter to all geocoding and search tools
+  - CategorySearchTool, ForwardGeocodeTool, PoiSearchTool, and ReverseGeocodeTool now support both `json_string` and `formatted_text` output formats
+  - `json_string` returns raw GeoJSON data as parseable JSON string
+  - `formatted_text` returns human-readable text with place names, addresses, and coordinates
+  - Default to `formatted_text` for backward compatibility
+  - Comprehensive test coverage for both output formats
+
 ## v0.1.0 (2025-06-12)
 
 - **Support-NPM-Package**: Introduce the NPM package of this mcp-server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,19 @@
 {
-  "name": "mapbox-mcp-server",
-  "version": "0.1.0",
+  "name": "@mapbox/mcp-server",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mapbox-mcp-server",
-      "version": "0.1.0",
-      "license": "No License",
+      "name": "@mapbox/mcp-server",
+      "version": "0.2.0",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "zod": "^3.25.42"
+      },
+      "bin": {
+        "mcp-server": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Mapbox MCP server.",
   "main": "dist/index.js",
   "module": "dist/index-esm.js",

--- a/src/tools/category-search-tool/CategorySearchTool.test.ts
+++ b/src/tools/category-search-tool/CategorySearchTool.test.ts
@@ -384,4 +384,71 @@ describe('CategorySearchTool', () => {
     expect(textContent).toContain('Coordinates: 40.7128, -74.006');
     expect(textContent).not.toContain('Address:');
   });
+
+  it('returns JSON string format when requested', async () => {
+    const mockResponse = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {
+            name: 'Test Restaurant',
+            full_address: '123 Test St, Test City, TC 12345'
+          },
+          geometry: {
+            type: 'Point',
+            coordinates: [-122.676, 45.515]
+          }
+        }
+      ]
+    };
+
+    const mockFetch = setupFetch({
+      json: async () => mockResponse
+    });
+
+    const result = await new CategorySearchTool().run({
+      category: 'restaurant',
+      format: 'json_string'
+    });
+
+    expect(result.is_error).toBe(false);
+    expect(result.content[0].type).toBe('text');
+
+    const jsonContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
+    expect(JSON.parse(jsonContent)).toEqual(mockResponse);
+  });
+
+  it('defaults to formatted_text format when format not specified', async () => {
+    const mockResponse = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {
+            name: 'Test Cafe'
+          },
+          geometry: {
+            type: 'Point',
+            coordinates: [-122.676, 45.515]
+          }
+        }
+      ]
+    };
+
+    const mockFetch = setupFetch({
+      json: async () => mockResponse
+    });
+
+    const result = await new CategorySearchTool().run({
+      category: 'cafe'
+    });
+
+    expect(result.is_error).toBe(false);
+    expect(result.content[0].type).toBe('text');
+    expect(
+      (result.content[0] as { type: 'text'; text: string }).text
+    ).toContain('1. Test Cafe');
+  });
 });

--- a/src/tools/poi-search-tool/PoiSearchTool.test.ts
+++ b/src/tools/poi-search-tool/PoiSearchTool.test.ts
@@ -443,4 +443,71 @@ describe('PoiSearchTool', () => {
     expect(textContent).toContain('Coordinates: 40.7128, -74.006');
     expect(textContent).not.toContain('Address:');
   });
+
+  it('returns JSON string format when requested', async () => {
+    const mockResponse = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {
+            name: 'Test POI',
+            full_address: '123 Test St, Test City, TC 12345'
+          },
+          geometry: {
+            type: 'Point',
+            coordinates: [-122.676, 45.515]
+          }
+        }
+      ]
+    };
+
+    const mockFetch = setupFetch({
+      json: async () => mockResponse
+    });
+
+    const result = await new PoiSearchTool().run({
+      q: 'Test POI',
+      format: 'json_string'
+    });
+
+    expect(result.is_error).toBe(false);
+    expect(result.content[0].type).toBe('text');
+
+    const jsonContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
+    expect(JSON.parse(jsonContent)).toEqual(mockResponse);
+  });
+
+  it('defaults to formatted_text format when format not specified', async () => {
+    const mockResponse = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {
+            name: 'Test Place'
+          },
+          geometry: {
+            type: 'Point',
+            coordinates: [-122.676, 45.515]
+          }
+        }
+      ]
+    };
+
+    const mockFetch = setupFetch({
+      json: async () => mockResponse
+    });
+
+    const result = await new PoiSearchTool().run({
+      q: 'Test Place'
+    });
+
+    expect(result.is_error).toBe(false);
+    expect(result.content[0].type).toBe('text');
+    expect(
+      (result.content[0] as { type: 'text'; text: string }).text
+    ).toContain('1. Test Place');
+  });
 });

--- a/src/tools/poi-search-tool/PoiSearchTool.ts
+++ b/src/tools/poi-search-tool/PoiSearchTool.ts
@@ -115,6 +115,13 @@ const PoiSearchInputSchema = z.object({
     .optional()
     .describe(
       'Starting point for ETA calculations as coordinate object with longitude and latitude'
+    ),
+  format: z
+    .enum(['json_string', 'formatted_text'])
+    .optional()
+    .default('formatted_text')
+    .describe(
+      'Output format: "json_string" returns raw GeoJSON data as a JSON string that can be parsed; "formatted_text" returns human-readable text with place names, addresses, and coordinates. Both return as text content but json_string contains parseable JSON data while formatted_text is for display.'
     )
 });
 
@@ -123,7 +130,7 @@ export class PoiSearchTool extends MapboxApiBasedTool<
 > {
   name = 'PoiSearchTool';
   description =
-    "Find one specific place or brand location by its proper name or unique brand. Use only when the user's query includes a distinct title (e.g., \"The Met\", \"Starbucks Reserve Roastery\") or a brand they want all nearby branches of (e.g., \"Macy's stores near me\"). Do not use for generic place types such as 'museums', 'coffee shops', 'tacos', etc. Setting a proximity point is strongly encouraged for more relevant results. Always try to use a limit of at least 3 in case the user's intended result is not the first result.";
+    "Find one specific place or brand location by its proper name or unique brand. Use only when the user's query includes a distinct title (e.g., \"The Met\", \"Starbucks Reserve Roastery\") or a brand they want all nearby branches of (e.g., \"Macy's stores near me\"). Do not use for generic place types such as 'museums', 'coffee shops', 'tacos', etc. Setting a proximity point is strongly encouraged for more relevant results. Always try to use a limit of at least 3 in case the user's intended result is not the first result. Supports both JSON and text output formats.";
 
   constructor() {
     super({ inputSchema: PoiSearchInputSchema });
@@ -282,6 +289,10 @@ export class PoiSearchTool extends MapboxApiBasedTool<
       `PoiSearchTool: Successfully completed search, found ${(data as any).features?.length || 0} results`
     );
 
-    return { type: 'text', text: this.formatGeoJsonToText(data) };
+    if (input.format === 'json_string') {
+      return { type: 'text', text: JSON.stringify(data, null, 2) };
+    } else {
+      return { type: 'text', text: this.formatGeoJsonToText(data) };
+    }
   }
 }

--- a/src/tools/reverse-geocode-tool/ReverseGeocodeTool.test.ts
+++ b/src/tools/reverse-geocode-tool/ReverseGeocodeTool.test.ts
@@ -430,4 +430,73 @@ describe('ReverseGeocodeTool', () => {
     expect(textContent).toContain('Coordinates: 35.456, -100.123');
     expect(textContent).not.toContain('Address:');
   });
+
+  it('returns JSON string format when requested', async () => {
+    const mockResponse = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {
+            name: 'Test Address',
+            full_address: '123 Test St, Test City, TC 12345'
+          },
+          geometry: {
+            type: 'Point',
+            coordinates: [-122.676, 45.515]
+          }
+        }
+      ]
+    };
+
+    const mockFetch = setupFetch({
+      json: async () => mockResponse
+    });
+
+    const result = await new ReverseGeocodeTool().run({
+      longitude: -122.676,
+      latitude: 45.515,
+      format: 'json_string'
+    });
+
+    expect(result.is_error).toBe(false);
+    expect(result.content[0].type).toBe('text');
+
+    const jsonContent = (result.content[0] as { type: 'text'; text: string })
+      .text;
+    expect(JSON.parse(jsonContent)).toEqual(mockResponse);
+  });
+
+  it('defaults to formatted_text format when format not specified', async () => {
+    const mockResponse = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {
+            name: 'Test Location'
+          },
+          geometry: {
+            type: 'Point',
+            coordinates: [-122.676, 45.515]
+          }
+        }
+      ]
+    };
+
+    const mockFetch = setupFetch({
+      json: async () => mockResponse
+    });
+
+    const result = await new ReverseGeocodeTool().run({
+      longitude: -122.676,
+      latitude: 45.515
+    });
+
+    expect(result.is_error).toBe(false);
+    expect(result.content[0].type).toBe('text');
+    expect(
+      (result.content[0] as { type: 'text'; text: string }).text
+    ).toContain('1. Test Location');
+  });
 });

--- a/src/tools/reverse-geocode-tool/ReverseGeocodeTool.ts
+++ b/src/tools/reverse-geocode-tool/ReverseGeocodeTool.ts
@@ -55,7 +55,14 @@ const ReverseGeocodeInputSchema = z.object({
     .enum(['us', 'cn', 'jp', 'in'])
     .optional()
     .default('us')
-    .describe('Returns features from a specific regional perspective')
+    .describe('Returns features from a specific regional perspective'),
+  format: z
+    .enum(['json_string', 'formatted_text'])
+    .optional()
+    .default('formatted_text')
+    .describe(
+      'Output format: "json_string" returns raw GeoJSON data as a JSON string that can be parsed; "formatted_text" returns human-readable text with place names, addresses, and coordinates. Both return as text content but json_string contains parseable JSON data while formatted_text is for display.'
+    )
 });
 
 export class ReverseGeocodeTool extends MapboxApiBasedTool<
@@ -63,7 +70,7 @@ export class ReverseGeocodeTool extends MapboxApiBasedTool<
 > {
   name = 'ReverseGeocodeTool';
   description =
-    'Find addresses, cities, towns, neighborhoods, postcodes, districts, regions, and countries around a specified geographic coordinate pair. Converts geographic coordinates (longitude, latitude) into human-readable addresses or place names. Use limit=1 for best results. This tool cannot reverse geocode businesses, landmarks, historic sites, and other points of interest that are not of the types mentioned.';
+    'Find addresses, cities, towns, neighborhoods, postcodes, districts, regions, and countries around a specified geographic coordinate pair. Converts geographic coordinates (longitude, latitude) into human-readable addresses or place names. Use limit=1 for best results. This tool cannot reverse geocode businesses, landmarks, historic sites, and other points of interest that are not of the types mentioned. Supports both JSON and text output formats.';
 
   constructor() {
     super({ inputSchema: ReverseGeocodeInputSchema });
@@ -174,6 +181,10 @@ export class ReverseGeocodeTool extends MapboxApiBasedTool<
       return { type: 'text', text: 'No results found.' };
     }
 
-    return { type: 'text', text: this.formatGeoJsonToText(data) };
+    if (input.format === 'json_string') {
+      return { type: 'text', text: JSON.stringify(data, null, 2) };
+    } else {
+      return { type: 'text', text: this.formatGeoJsonToText(data) };
+    }
   }
 }


### PR DESCRIPTION
## Description


- **Format Options**: Add `format` parameter to all geocoding and search tools
  - CategorySearchTool, ForwardGeocodeTool, PoiSearchTool, and ReverseGeocodeTool now support both `json_string` and `formatted_text` output formats
  - `json_string` returns raw GeoJSON data as parseable JSON string
  - `formatted_text` returns human-readable text with place names, addresses, and coordinates
  - Default to `formatted_text` for backward compatibility
  - Comprehensive test coverage for both output formats


<!-- Provide a clear explanation of what has been implemented or fixed. Mention any related context, requirements, or issues. -->


---

## Testing

<!-- Include logs, screenshots, terminal output, or any relevant proof of successful testing. -->

---

## Checklist

- [ ] Code has been tested locally
- [ ] Unit tests have been added or updated
- [ ] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
