### PR TITLE
Optimize directions tool for number of tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,12 @@ Fetches routing directions using the [Mapbox Directions API](https://docs.mapbox
   - Future departure time (`depart_at`) for driving and driving-traffic profiles
   - Desired arrival time (`arrive_by`) for driving profile only
 - Profile-specific optimizations:
-  - Walking: customizable walking speed and bias for/against walkways
   - Driving: vehicle dimension constraints (height, width, weight)
 - Exclusion options for routing:
   - Common exclusions: ferry routes, cash-only tolls
   - Driving-specific exclusions: tolls, motorways, unpaved roads, tunnels, country borders, state borders
   - Custom point exclusions (up to 50 geographic points to avoid)
-- Multiple geometry output formats (GeoJSON, polyline)
+- GeoJSON geometry output format
 
 #### Isochrone tool
 

--- a/src/tools/directions-tool/DirectionsTool.test.ts
+++ b/src/tools/directions-tool/DirectionsTool.test.ts
@@ -1,4 +1,4 @@
-process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
+process.env.MAPBOX_ACCESS_TOKEN = 'test.token.signature';
 
 import { cleanup } from '../../utils/requestUtils.js';
 import {
@@ -15,6 +15,9 @@ describe('DirectionsTool', () => {
     jest
       .spyOn(cleanResponseModule, 'cleanResponseData')
       .mockImplementation((_, data) => data);
+
+    // Enable verbose errors for testing
+    process.env.VERBOSE_ERRORS = 'true';
   });
 
   afterEach(() => {
@@ -158,7 +161,7 @@ describe('DirectionsTool', () => {
     expect(result.is_error).toBe(true);
     expect(result.content[0]).toMatchObject({
       type: 'text',
-      text: 'Internal error has occurred.'
+      text: 'Request failed with status 404: Not Found'
     });
     assertHeadersSent(mockFetch);
   });

--- a/src/tools/directions-tool/DirectionsTool.test.ts
+++ b/src/tools/directions-tool/DirectionsTool.test.ts
@@ -1,5 +1,4 @@
-process.env.MAPBOX_ACCESS_TOKEN =
-  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature';
+process.env.MAPBOX_ACCESS_TOKEN = 'test-token';
 
 import { cleanup } from '../../utils/requestUtils.js';
 import {
@@ -7,8 +6,17 @@ import {
   assertHeadersSent
 } from '../../utils/requestUtils.test-helpers.js';
 import { DirectionsTool } from './DirectionsTool.js';
+import * as cleanResponseModule from './cleanResponseData.js';
 
 describe('DirectionsTool', () => {
+  beforeEach(() => {
+    // Mock the cleanResponseData function to return data unchanged, this make testing much easier
+    // There should be separate test suits for `cleanResponseData`
+    jest
+      .spyOn(cleanResponseModule, 'cleanResponseData')
+      .mockImplementation((_, data) => data);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
     cleanup();
@@ -19,8 +27,8 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        { longitude: -74.102094, latitude: 40.692815 },
-        { longitude: -74.1022094, latitude: 40.792815 }
+        [-74.102094, 40.692815],
+        [-74.1022094, 40.792815]
       ]
     });
 
@@ -32,8 +40,8 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        { longitude: -73.989, latitude: 40.733 },
-        { longitude: -73.979, latitude: 40.743 }
+        [-73.989, 40.733],
+        [-73.979, 40.743]
       ]
     });
 
@@ -49,14 +57,13 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        { longitude: -122.42, latitude: 37.78 },
-        { longitude: -122.4, latitude: 37.79 },
-        { longitude: -122.39, latitude: 37.77 }
+        [-122.42, 37.78],
+        [-122.4, 37.79],
+        [-122.39, 37.77]
       ],
       routing_profile: 'walking',
       geometries: 'geojson',
       alternatives: true,
-      annotations: ['distance', 'duration', 'speed'],
       exclude: 'ferry'
     });
 
@@ -67,7 +74,7 @@ describe('DirectionsTool', () => {
     );
     expect(calledUrl).toContain('geometries=geojson');
     expect(calledUrl).toContain('alternatives=true');
-    expect(calledUrl).toContain('annotations=distance%2Cduration%2Cspeed');
+    expect(calledUrl).toContain('annotations=distance%2Cspeed');
     expect(calledUrl).toContain('overview=full');
     expect(calledUrl).toContain('exclude=ferry');
     assertHeadersSent(mockFetch);
@@ -78,16 +85,36 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        { longitude: -118.24, latitude: 34.05 },
-        { longitude: -118.3, latitude: 34.02 }
+        [-118.24, 34.05],
+        [-118.3, 34.02]
       ]
     });
 
     const calledUrl = mockFetch.mock.calls[0][0];
     expect(calledUrl).toContain('directions/v5/mapbox/driving-traffic');
-    expect(calledUrl).toContain('geometries=polyline');
+    expect(calledUrl).not.toContain('geometries=');
     expect(calledUrl).toContain('alternatives=false');
-    expect(calledUrl).not.toContain('annotations=');
+    expect(calledUrl).toContain('annotations=distance%2Ccongestion%2Cspeed');
+    expect(calledUrl).not.toContain('exclude=');
+    assertHeadersSent(mockFetch);
+  });
+
+  it('handles geometries=none', async () => {
+    const mockFetch = setupFetch();
+
+    await new DirectionsTool().run({
+      coordinates: [
+        [-118.24, 34.05],
+        [-118.3, 34.02]
+      ],
+      geometries: 'none'
+    });
+
+    const calledUrl = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('directions/v5/mapbox/driving-traffic');
+    expect(calledUrl).not.toContain('geometries=');
+    expect(calledUrl).toContain('alternatives=false');
+    expect(calledUrl).toContain('annotations=distance%2Ccongestion%2Cspeed');
     expect(calledUrl).not.toContain('exclude=');
     assertHeadersSent(mockFetch);
   });
@@ -97,8 +124,8 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        { longitude: -74.0, latitude: 40.7 },
-        { longitude: -73.9, latitude: 40.8 }
+        [-74.0, 40.7],
+        [-73.9, 40.8]
       ],
       exclude: 'toll,point(-73.95 40.75)'
     });
@@ -123,8 +150,8 @@ describe('DirectionsTool', () => {
 
     const result = await new DirectionsTool().run({
       coordinates: [
-        { longitude: -73.989, latitude: 40.733 },
-        { longitude: -73.979, latitude: 40.743 }
+        [-73.989, 40.733],
+        [-73.979, 40.743]
       ]
     });
 
@@ -142,7 +169,7 @@ describe('DirectionsTool', () => {
     // Test with only one coordinate (invalid)
     await expect(
       tool.run({
-        coordinates: [{ longitude: -73.989, latitude: 40.733 }]
+        coordinates: [[-73.989, 40.733]]
       })
     ).resolves.toMatchObject({
       is_error: true
@@ -162,10 +189,7 @@ describe('DirectionsTool', () => {
     const tool = new DirectionsTool();
 
     // Create an array of 26 coordinates (one more than allowed)
-    const tooManyCoords = Array(26).fill({
-      longitude: -73.989,
-      latitude: 40.733
-    });
+    const tooManyCoords = Array(26).fill([-73.989, 40.733]);
 
     await expect(
       tool.run({
@@ -181,8 +205,8 @@ describe('DirectionsTool', () => {
 
     await new DirectionsTool().run({
       coordinates: [
-        { longitude: -73.989, latitude: 40.733 },
-        { longitude: -73.979, latitude: 40.743 }
+        [-73.989, 40.733],
+        [-73.979, 40.743]
       ]
     });
 
@@ -197,7 +221,7 @@ describe('DirectionsTool', () => {
     // Create an array of exactly 25 coordinates (maximum allowed)
     const maxCoords = Array(25)
       .fill(0)
-      .map((_, i) => ({ longitude: -74 + i * 0.01, latitude: 40 + i * 0.01 }));
+      .map((_, i) => [-74 + i * 0.01, 40 + i * 0.01]);
 
     await new DirectionsTool().run({
       coordinates: maxCoords
@@ -207,203 +231,13 @@ describe('DirectionsTool', () => {
 
     // Check that all coordinates are properly encoded
     for (let i = 0; i < maxCoords.length; i++) {
-      const { longitude: lng, latitude: lat } = maxCoords[i];
+      const [lng, lat] = maxCoords[i];
       const semicolon = i < 24 ? '%3B' : '';
       const expectedCoord = `${lng}%2C${lat}` + semicolon;
       expect(calledUrl).toContain(expectedCoord);
     }
 
     assertHeadersSent(mockFetch);
-  });
-
-  describe('walking parameters validations', () => {
-    it('accepts walking_speed with walking profile', async () => {
-      const mockFetch = setupFetch();
-
-      await new DirectionsTool().run({
-        coordinates: [
-          { longitude: -73.989, latitude: 40.733 },
-          { longitude: -73.979, latitude: 40.743 }
-        ],
-        routing_profile: 'walking',
-        walking_speed: 2.5
-      });
-
-      const calledUrl = mockFetch.mock.calls[0][0];
-      expect(calledUrl).toContain('walking_speed=2.5');
-      assertHeadersSent(mockFetch);
-    });
-
-    it('accepts walkway_bias with walking profile', async () => {
-      const mockFetch = setupFetch();
-
-      await new DirectionsTool().run({
-        coordinates: [
-          { longitude: -73.989, latitude: 40.733 },
-          { longitude: -73.979, latitude: 40.743 }
-        ],
-        routing_profile: 'walking',
-        walkway_bias: 0.8
-      });
-
-      const calledUrl = mockFetch.mock.calls[0][0];
-      expect(calledUrl).toContain('walkway_bias=0.8');
-      assertHeadersSent(mockFetch);
-    });
-
-    it('rejects walking_speed with non-walking profiles', async () => {
-      const tool = new DirectionsTool();
-
-      // Test with driving profile
-      await expect(
-        tool.run({
-          coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
-          ],
-          routing_profile: 'driving',
-          walking_speed: 2.0
-        })
-      ).resolves.toMatchObject({
-        is_error: true
-      });
-
-      // Test with cycling profile
-      await expect(
-        tool.run({
-          coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
-          ],
-          routing_profile: 'cycling',
-          walking_speed: 2.0
-        })
-      ).resolves.toMatchObject({
-        is_error: true
-      });
-    });
-
-    it('rejects walkway_bias with non-walking profiles', async () => {
-      const tool = new DirectionsTool();
-
-      // Test with driving-traffic profile
-      await expect(
-        tool.run({
-          coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
-          ],
-          routing_profile: 'driving-traffic',
-          walkway_bias: 0.5
-        })
-      ).resolves.toMatchObject({
-        is_error: true
-      });
-
-      // Test with cycling profile
-      await expect(
-        tool.run({
-          coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
-          ],
-          routing_profile: 'cycling',
-          walkway_bias: -0.8
-        })
-      ).resolves.toMatchObject({
-        is_error: true
-      });
-    });
-
-    it('validates walking_speed value ranges', async () => {
-      const tool = new DirectionsTool();
-
-      // Test with value below minimum (0.14 m/s)
-      await expect(
-        tool.run({
-          coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
-          ],
-          routing_profile: 'walking',
-          walking_speed: 0.1
-        })
-      ).resolves.toMatchObject({
-        is_error: true
-      });
-
-      // Test with value above maximum (6.94 m/s)
-      await expect(
-        tool.run({
-          coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
-          ],
-          routing_profile: 'walking',
-          walking_speed: 7.5
-        })
-      ).resolves.toMatchObject({
-        is_error: true
-      });
-
-      // Test with valid value
-      const mockFetch = setupFetch();
-      await tool.run({
-        coordinates: [
-          { longitude: -73.989, latitude: 40.733 },
-          { longitude: -73.979, latitude: 40.743 }
-        ],
-        routing_profile: 'walking',
-        walking_speed: 3.0
-      });
-      const calledUrl = mockFetch.mock.calls[0][0];
-      expect(calledUrl).toContain('walking_speed=3');
-    });
-
-    it('validates walkway_bias value ranges', async () => {
-      const tool = new DirectionsTool();
-
-      // Test with value below minimum (-1)
-      await expect(
-        tool.run({
-          coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
-          ],
-          routing_profile: 'walking',
-          walkway_bias: -1.5
-        })
-      ).resolves.toMatchObject({
-        is_error: true
-      });
-
-      // Test with value above maximum (1)
-      await expect(
-        tool.run({
-          coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
-          ],
-          routing_profile: 'walking',
-          walkway_bias: 1.2
-        })
-      ).resolves.toMatchObject({
-        is_error: true
-      });
-
-      // Test with valid values
-      const mockFetch = setupFetch();
-      await tool.run({
-        coordinates: [
-          { longitude: -73.989, latitude: 40.733 },
-          { longitude: -73.979, latitude: 40.743 }
-        ],
-        routing_profile: 'walking',
-        walkway_bias: -0.5
-      });
-      const calledUrl = mockFetch.mock.calls[0][0];
-      expect(calledUrl).toContain('walkway_bias=-0.5');
-    });
   });
 
   describe('exclude parameter and routing profile validations', () => {
@@ -415,8 +249,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'driving',
           exclude: 'toll,motorway,unpaved'
@@ -429,8 +263,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'driving-traffic',
           exclude: 'tunnel,country_border,state_border'
@@ -447,8 +281,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'walking',
           exclude: 'toll'
@@ -461,8 +295,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'cycling',
           exclude: 'motorway'
@@ -480,8 +314,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'driving',
           exclude: 'ferry'
@@ -494,8 +328,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'walking',
           exclude: 'ferry'
@@ -508,8 +342,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'cycling',
           exclude: 'cash_only_tolls'
@@ -527,8 +361,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'driving',
           exclude: 'point(-73.95 40.75)'
@@ -541,8 +375,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'walking',
           exclude: 'point(-73.95 40.75)'
@@ -555,8 +389,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'cycling',
           exclude: 'point(-73.95 40.75)'
@@ -574,8 +408,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'driving',
           exclude: 'toll,motorway,ferry,cash_only_tolls,point(-73.95 40.75)'
@@ -588,8 +422,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'walking',
           exclude: 'ferry,toll'
@@ -602,8 +436,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'cycling',
           exclude: 'ferry,cash_only_tolls'
@@ -624,8 +458,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'driving',
           depart_at: validDateTime
@@ -643,8 +477,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'driving-traffic',
           depart_at: validDateTime
@@ -668,8 +502,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              { longitude: -73.989, latitude: 40.733 },
-              { longitude: -73.979, latitude: 40.743 }
+              [-73.989, 40.733],
+              [-73.979, 40.743]
             ],
             routing_profile: 'driving',
             max_height: 4.5,
@@ -689,8 +523,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              { longitude: -73.989, latitude: 40.733 },
-              { longitude: -73.979, latitude: 40.743 }
+              [-73.989, 40.733],
+              [-73.979, 40.743]
             ],
             routing_profile: 'driving-traffic',
             max_height: 3.2
@@ -710,8 +544,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              { longitude: -73.989, latitude: 40.733 },
-              { longitude: -73.979, latitude: 40.743 }
+              [-73.989, 40.733],
+              [-73.979, 40.743]
             ],
             routing_profile: 'walking',
             max_height: 4.5
@@ -724,8 +558,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              { longitude: -73.989, latitude: 40.733 },
-              { longitude: -73.979, latitude: 40.743 }
+              [-73.989, 40.733],
+              [-73.979, 40.743]
             ],
             routing_profile: 'cycling',
             max_width: 2.0
@@ -742,8 +576,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              { longitude: -73.989, latitude: 40.733 },
-              { longitude: -73.979, latitude: 40.743 }
+              [-73.989, 40.733],
+              [-73.979, 40.743]
             ],
             routing_profile: 'driving',
             max_height: 15.0
@@ -756,8 +590,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              { longitude: -73.989, latitude: 40.733 },
-              { longitude: -73.979, latitude: 40.743 }
+              [-73.989, 40.733],
+              [-73.979, 40.743]
             ],
             routing_profile: 'driving',
             max_width: -1.0
@@ -770,8 +604,8 @@ describe('DirectionsTool', () => {
         await expect(
           tool.run({
             coordinates: [
-              { longitude: -73.989, latitude: 40.733 },
-              { longitude: -73.979, latitude: 40.743 }
+              [-73.989, 40.733],
+              [-73.979, 40.743]
             ],
             routing_profile: 'driving',
             max_weight: 150.0
@@ -790,8 +624,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'walking',
           depart_at: validDateTime
@@ -804,8 +638,8 @@ describe('DirectionsTool', () => {
       await expect(
         tool.run({
           coordinates: [
-            { longitude: -73.989, latitude: 40.733 },
-            { longitude: -73.979, latitude: 40.743 }
+            [-73.989, 40.733],
+            [-73.979, 40.743]
           ],
           routing_profile: 'cycling',
           depart_at: validDateTime
@@ -819,8 +653,8 @@ describe('DirectionsTool', () => {
       const mockFetch = setupFetch();
       const tool = new DirectionsTool();
       const baseCoordinates = [
-        { longitude: -73.989, latitude: 40.733 },
-        { longitude: -73.979, latitude: 40.743 }
+        [-73.989, 40.733],
+        [-73.979, 40.743]
       ];
 
       // Format 1: YYYY-MM-DDThh:mm:ssZ
@@ -857,8 +691,8 @@ describe('DirectionsTool', () => {
     it('rejects invalid date-time formats', async () => {
       const tool = new DirectionsTool();
       const baseCoordinates = [
-        { longitude: -73.989, latitude: 40.733 },
-        { longitude: -73.979, latitude: 40.743 }
+        [-73.989, 40.733],
+        [-73.979, 40.743]
       ];
 
       // Invalid format examples
@@ -889,8 +723,8 @@ describe('DirectionsTool', () => {
     it('rejects dates with invalid components', async () => {
       const tool = new DirectionsTool();
       const baseCoordinates = [
-        { longitude: -73.989, latitude: 40.733 },
-        { longitude: -73.979, latitude: 40.743 }
+        [-73.989, 40.733],
+        [-73.979, 40.743]
       ];
 
       // Invalid time components
@@ -913,6 +747,65 @@ describe('DirectionsTool', () => {
         });
       }
     });
+
+    it('depart_at accepts and converts YYYY-MM-DDThh:mm:ss format (seconds but no timezone)', async () => {
+      const mockFetch = setupFetch();
+      const tool = new DirectionsTool();
+
+      const dateTimeWithSeconds = '2025-06-05T10:30:45';
+      const expectedConvertedDateTime = '2025-06-05T10:30'; // Without seconds
+
+      await expect(
+        tool.run({
+          coordinates: [
+            [-73.989, 40.733],
+            [-73.979, 40.743]
+          ],
+          depart_at: dateTimeWithSeconds
+        })
+      ).resolves.not.toMatchObject({
+        is_error: true
+      });
+
+      // Verify the seconds were stripped in the API call
+      const calledUrl = mockFetch.mock.calls[0][0];
+      expect(calledUrl).toContain(
+        `depart_at=${encodeURIComponent(expectedConvertedDateTime)}`
+      );
+      expect(calledUrl).not.toContain(
+        `depart_at=${encodeURIComponent(dateTimeWithSeconds)}`
+      );
+    });
+
+    it('arrive_by accepts and converts YYYY-MM-DDThh:mm:ss format (seconds but no timezone)', async () => {
+      const mockFetch = setupFetch();
+      const tool = new DirectionsTool();
+
+      const dateTimeWithSeconds = '2025-06-05T10:30:45';
+      const expectedConvertedDateTime = '2025-06-05T10:30'; // Without seconds
+
+      await expect(
+        tool.run({
+          coordinates: [
+            [-73.989, 40.733],
+            [-73.979, 40.743]
+          ],
+          routing_profile: 'driving',
+          arrive_by: dateTimeWithSeconds
+        })
+      ).resolves.not.toMatchObject({
+        is_error: true
+      });
+
+      // Verify the seconds were stripped in the API call
+      const calledUrl = mockFetch.mock.calls[0][0];
+      expect(calledUrl).toContain(
+        `arrive_by=${encodeURIComponent(expectedConvertedDateTime)}`
+      );
+      expect(calledUrl).not.toContain(
+        `arrive_by=${encodeURIComponent(dateTimeWithSeconds)}`
+      );
+    });
   });
 
   describe('arrive_by parameter validations', () => {
@@ -923,8 +816,8 @@ describe('DirectionsTool', () => {
       // Test with driving profile - should work
       await new DirectionsTool().run({
         coordinates: [
-          { longitude: -74.1, latitude: 40.7 },
-          { longitude: -74.2, latitude: 40.8 }
+          [-74.1, 40.7],
+          [-74.2, 40.8]
         ],
         routing_profile: 'driving',
         arrive_by: validDateTime
@@ -943,8 +836,8 @@ describe('DirectionsTool', () => {
       // Test with driving-traffic profile
       const result1 = await new DirectionsTool().run({
         coordinates: [
-          { longitude: -74.1, latitude: 40.7 },
-          { longitude: -74.2, latitude: 40.8 }
+          [-74.1, 40.7],
+          [-74.2, 40.8]
         ],
         routing_profile: 'driving-traffic',
         arrive_by: validDateTime
@@ -955,8 +848,8 @@ describe('DirectionsTool', () => {
       // Test with walking profile
       const result2 = await new DirectionsTool().run({
         coordinates: [
-          { longitude: -74.1, latitude: 40.7 },
-          { longitude: -74.2, latitude: 40.8 }
+          [-74.1, 40.7],
+          [-74.2, 40.8]
         ],
         routing_profile: 'walking',
         arrive_by: validDateTime
@@ -967,8 +860,8 @@ describe('DirectionsTool', () => {
       // Test with cycling profile
       const result3 = await new DirectionsTool().run({
         coordinates: [
-          { longitude: -74.1, latitude: 40.7 },
-          { longitude: -74.2, latitude: 40.8 }
+          [-74.1, 40.7],
+          [-74.2, 40.8]
         ],
         routing_profile: 'cycling',
         arrive_by: validDateTime
@@ -980,8 +873,8 @@ describe('DirectionsTool', () => {
     it('rejects when both arrive_by and depart_at are provided', async () => {
       const result = await new DirectionsTool().run({
         coordinates: [
-          { longitude: -74.1, latitude: 40.7 },
-          { longitude: -74.2, latitude: 40.8 }
+          [-74.1, 40.7],
+          [-74.2, 40.8]
         ],
         routing_profile: 'driving',
         depart_at: '2025-06-05T09:30:00Z',
@@ -997,8 +890,8 @@ describe('DirectionsTool', () => {
       // Test with Z format
       await new DirectionsTool().run({
         coordinates: [
-          { longitude: -74.1, latitude: 40.7 },
-          { longitude: -74.2, latitude: 40.8 }
+          [-74.1, 40.7],
+          [-74.2, 40.8]
         ],
         routing_profile: 'driving',
         arrive_by: '2025-06-05T10:30:00Z'
@@ -1010,8 +903,8 @@ describe('DirectionsTool', () => {
       // Test with timezone offset format
       await new DirectionsTool().run({
         coordinates: [
-          { longitude: -74.1, latitude: 40.7 },
-          { longitude: -74.2, latitude: 40.8 }
+          [-74.1, 40.7],
+          [-74.2, 40.8]
         ],
         routing_profile: 'driving',
         arrive_by: '2025-06-05T10:30:00+02:00'
@@ -1023,8 +916,8 @@ describe('DirectionsTool', () => {
       // Test with simple time format (no seconds, no timezone)
       await new DirectionsTool().run({
         coordinates: [
-          { longitude: -74.1, latitude: 40.7 },
-          { longitude: -74.2, latitude: 40.8 }
+          [-74.1, 40.7],
+          [-74.2, 40.8]
         ],
         routing_profile: 'driving',
         arrive_by: '2025-06-05T10:30'
@@ -1056,8 +949,8 @@ describe('DirectionsTool', () => {
       for (const format of invalidFormats) {
         const result = await new DirectionsTool().run({
           coordinates: [
-            { longitude: -74.1, latitude: 40.7 },
-            { longitude: -74.2, latitude: 40.8 }
+            [-74.1, 40.7],
+            [-74.2, 40.8]
           ],
           routing_profile: 'driving',
           arrive_by: format
@@ -1080,8 +973,8 @@ describe('DirectionsTool', () => {
       for (const date of invalidDates) {
         const result = await new DirectionsTool().run({
           coordinates: [
-            { longitude: -74.1, latitude: 40.7 },
-            { longitude: -74.2, latitude: 40.8 }
+            [-74.1, 40.7],
+            [-74.2, 40.8]
           ],
           routing_profile: 'driving',
           arrive_by: date
@@ -1089,6 +982,63 @@ describe('DirectionsTool', () => {
 
         expect(result.is_error).toBe(true);
       }
+    });
+  });
+
+  it('validates geometries enum values', async () => {
+    const tool = new DirectionsTool();
+
+    // Valid values: 'none' and 'geojson'
+    await expect(
+      tool.run({
+        coordinates: [
+          [-73.989, 40.733],
+          [-73.979, 40.743]
+        ],
+        geometries: 'none'
+      })
+    ).resolves.not.toMatchObject({
+      is_error: true
+    });
+
+    await expect(
+      tool.run({
+        coordinates: [
+          [-73.989, 40.733],
+          [-73.979, 40.743]
+        ],
+        geometries: 'geojson'
+      })
+    ).resolves.not.toMatchObject({
+      is_error: true
+    });
+
+    // Invalid values: 'polyline' and 'polyline6' were removed
+    // Test with invalid string values (runtime validation)
+    await expect(
+      tool.run({
+        coordinates: [
+          [-73.989, 40.733],
+          [-73.979, 40.743]
+        ],
+        // @ts-ignore - Testing with invalid value for runtime validation
+        geometries: 'polyline'
+      })
+    ).resolves.toMatchObject({
+      is_error: true
+    });
+
+    await expect(
+      tool.run({
+        coordinates: [
+          [-73.989, 40.733],
+          [-73.979, 40.743]
+        ],
+        // @ts-ignore - Testing with invalid value for runtime validation
+        geometries: 'polyline6'
+      })
+    ).resolves.toMatchObject({
+      is_error: true
     });
   });
 });

--- a/src/tools/directions-tool/cleanResponseData.test.ts
+++ b/src/tools/directions-tool/cleanResponseData.test.ts
@@ -1,0 +1,329 @@
+import { cleanResponseData } from './cleanResponseData.js';
+
+describe('cleanResponseData', () => {
+  // Create a complete mock input that satisfies the DirectionsInputSchema
+  const mockInput = {
+    coordinates: [
+      [0, 0],
+      [1, 1]
+    ] as [number, number][], // Use a proper tuple type
+    routing_profile: 'driving-traffic' as const,
+    geometries: 'none' as const,
+    alternatives: false
+  };
+
+  it('should remove unnecessary keys', () => {
+    const mockData = {
+      uuid: '12345',
+      code: 'Ok',
+      routes: []
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+    expect(result.uuid).toBeUndefined();
+    expect(result.code).toBeUndefined();
+  });
+
+  it('should rename waypoint location and distance properties', () => {
+    const mockData = {
+      waypoints: [
+        {
+          name: 'Test',
+          location: [-73.989, 40.733],
+          distance: 10.5
+        }
+      ],
+      routes: []
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+    expect(result.waypoints[0].location).toBeUndefined();
+    expect(result.waypoints[0].snap_location).toEqual([-73.989, 40.733]);
+    expect(result.waypoints[0].distance).toBeUndefined();
+    expect(result.waypoints[0].snap_distance).toBe(11); // Rounded from 10.5
+  });
+
+  it('should round duration and distance', () => {
+    const mockData = {
+      routes: [
+        {
+          duration: 1234.56,
+          distance: 5678.91,
+          legs: []
+        }
+      ]
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+    expect(result.routes[0].duration).toBe(1235);
+    expect(result.routes[0].distance).toBe(5679);
+  });
+
+  it('should delete geometry when geometries is set to none', () => {
+    const mockData = {
+      routes: [
+        {
+          geometry: 'someGeometryData',
+          legs: []
+        }
+      ]
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+    expect(result.routes[0].geometry).toBeUndefined();
+  });
+
+  it('should keep geometry when geometries is not none', () => {
+    const mockData = {
+      routes: [
+        {
+          geometry: 'someGeometryData',
+          legs: []
+        }
+      ]
+    };
+
+    // Override just the geometries property for this test
+    const geojsonInput = {
+      ...mockInput,
+      geometries: 'geojson' as const
+    };
+
+    const result = cleanResponseData(geojsonInput, mockData);
+    expect(result.routes[0].geometry).toBe('someGeometryData');
+  });
+
+  it('should process route data correctly', () => {
+    const mockData = {
+      routes: [
+        {
+          duration: 1200,
+          distance: 5000,
+          weight_name: 'routingWeight',
+          weight: 1500,
+          duration_typical: 1300,
+          weight_typical: 1600,
+          legs: [
+            {
+              summary: 'First leg summary',
+              admins: [{ iso_3166_1_alpha3: 'USA' }],
+              steps: []
+            },
+            {
+              summary: 'Second leg summary',
+              admins: [{ iso_3166_1_alpha3: 'CAN' }],
+              steps: []
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+
+    // Check if data is properly processed
+    expect(result.routes[0].weight_name).toBeUndefined();
+    expect(result.routes[0].weight).toBeUndefined();
+    expect(result.routes[0].leg_summaries).toEqual([
+      'First leg summary',
+      'Second leg summary'
+    ]);
+    expect(result.routes[0].duration_typical).toBeUndefined();
+    expect(result.routes[0].duration_under_typical_traffic_conditions).toBe(
+      1300
+    );
+    expect(result.routes[0].weight_typical).toBeUndefined();
+    expect(result.routes[0].intersecting_admins).toEqual(['USA', 'CAN']);
+    expect(result.routes[0].num_legs).toBe(2);
+    expect(result.routes[0].legs).toBeUndefined();
+  });
+
+  it('should handle notifications and collect unique messages', () => {
+    const mockData = {
+      routes: [
+        {
+          legs: [
+            {
+              notifications: [
+                { details: { message: 'Traffic ahead' } },
+                { details: { message: 'Road closure' } }
+              ],
+              summary: 'Leg 1'
+            },
+            {
+              notifications: [
+                { details: { message: 'Traffic ahead' } },
+                { details: { message: 'Construction zone' } }
+              ],
+              summary: 'Leg 2'
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+
+    expect(result.routes[0].notifications_summary).toEqual([
+      'Traffic ahead',
+      'Road closure',
+      'Construction zone'
+    ]);
+  });
+
+  it('should process incidents information', () => {
+    const mockData = {
+      routes: [
+        {
+          legs: [
+            {
+              incidents: [
+                {
+                  type: 'accident',
+                  end_time: '2023-05-01T12:00:00Z',
+                  long_description: 'Multiple vehicle collision',
+                  impact: 'severe',
+                  affected_road_names: ['Main St'],
+                  length: 500,
+                  extra_field: 'should not be included'
+                }
+              ],
+              summary: 'Leg with incident'
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+
+    expect(result.routes[0].incidents_summary).toHaveLength(1);
+    expect(result.routes[0].incidents_summary[0]).toEqual({
+      type: 'accident',
+      end_time: '2023-05-01T12:00:00Z',
+      long_description: 'Multiple vehicle collision',
+      impact: 'severe',
+      affected_road_names: ['Main St'],
+      length: 500
+    });
+    expect(result.routes[0].incidents_summary[0].extra_field).toBeUndefined();
+  });
+
+  it('should collect voice instructions when within limits', () => {
+    const mockData = {
+      routes: [
+        {
+          legs: [
+            {
+              steps: [
+                {
+                  voiceInstructions: [
+                    { announcement: 'Turn right in 100 meters' },
+                    { announcement: 'Turn right now' }
+                  ]
+                },
+                {
+                  voiceInstructions: [
+                    { announcement: 'Continue straight for 500 meters' }
+                  ]
+                }
+              ],
+              summary: 'Leg with voice instructions'
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+
+    expect(result.routes[0].instructions).toEqual([
+      'Turn right in 100 meters',
+      'Turn right now',
+      'Continue straight for 500 meters'
+    ]);
+  });
+
+  it('should not include instructions when there are too many', () => {
+    const mockData = {
+      routes: [
+        {
+          legs: [
+            {
+              steps: Array(6)
+                .fill(0)
+                .map(() => ({
+                  voiceInstructions: [
+                    { announcement: 'Instruction 1' },
+                    { announcement: 'Instruction 2' }
+                  ]
+                })),
+              summary: 'Leg with many instructions'
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+
+    // With 6 steps and 2 instructions each, we'd have 12 instructions total
+    // The function should exclude them since it's > 10
+    expect(result.routes[0].instructions).toBeUndefined();
+  });
+
+  it('should calculate congestion information correctly', () => {
+    const mockData = {
+      routes: [
+        {
+          legs: [
+            {
+              annotation: {
+                congestion: ['severe', 'heavy', 'moderate', 'low', 'unknown'],
+                distance: [100, 200, 300, 400, 500]
+              },
+              summary: 'Leg with congestion'
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+
+    expect(result.routes[0].congestion_information).toEqual({
+      length_severe: 100,
+      length_heavy: 200,
+      length_moderate: 300,
+      length_low: 400
+    });
+    // Note: 'unknown' congestion type is skipped
+  });
+
+  it('should calculate average speed correctly', () => {
+    const mockData = {
+      routes: [
+        {
+          legs: [
+            {
+              annotation: {
+                speed: [10, 20, 30], // m/s
+                distance: [100, 200, 300] // meters
+              },
+              summary: 'Leg with speed data'
+            }
+          ]
+        }
+      ]
+    };
+
+    const result = cleanResponseData(mockInput, mockData);
+
+    // Calculation:
+    // Weighted sum = 10*100 + 20*200 + 30*300 = 1000 + 4000 + 9000 = 14000
+    // Total distance = 100 + 200 + 300 = 600
+    // Average m/s = 14000/600 = 23.33
+    // Average km/h = 23.33 * 3.6 = 84 (rounded)
+    expect(result.routes[0].average_speed_kph).toBe(84);
+  });
+});

--- a/src/tools/directions-tool/cleanResponseData.ts
+++ b/src/tools/directions-tool/cleanResponseData.ts
@@ -1,0 +1,218 @@
+import { z } from 'zod';
+import { DirectionsInputSchema } from './DirectionsTool.js';
+
+/**
+ * Cleans up the API response to reduce token count while preserving useful data.
+ *
+ * @param input The original input parameters used for the request
+ * @param data The raw response data from the Mapbox Directions API
+ * @returns Cleaned data with reduced token count
+ */
+export function cleanResponseData(
+  input: z.infer<typeof DirectionsInputSchema>,
+  data: any
+): any {
+  // Remove unnecessary keys to reduce token count
+  if ('uuid' in data) {
+    delete data.uuid;
+  }
+
+  if ('code' in data) {
+    delete data.code;
+  }
+
+  if ('waypoints' in data) {
+    // rename each waypoint's location to `snap_location` and distance to `snap_distance`
+    // this is not really necessary, but hopefully agents will find this more obvious that we have snapping
+    data.waypoints = data.waypoints.map((waypoint: any) => {
+      const updatedWaypoint = { ...waypoint };
+      if ('location' in updatedWaypoint) {
+        updatedWaypoint.snap_location = updatedWaypoint.location;
+        delete updatedWaypoint.location;
+      }
+      if ('distance' in updatedWaypoint) {
+        updatedWaypoint.snap_distance = Math.round(updatedWaypoint.distance);
+        delete updatedWaypoint.distance;
+      }
+      return updatedWaypoint;
+    });
+  }
+
+  if (!('routes' in data)) {
+    // lets return early because there is nothing more we could do here
+    return data;
+  }
+
+  data.routes.forEach((route: any) => {
+    // Round duration and distance to integers if they exist
+    if (route.duration !== undefined) {
+      route.duration = Math.round(route.duration);
+    }
+    if (route.distance !== undefined) {
+      route.distance = Math.round(route.distance);
+    }
+
+    delete route.weight_name;
+    delete route.weight;
+
+    // Handle the case where geometry is not included (when geometries='none')
+    if (input.geometries === 'none' && route.geometry) {
+      delete route.geometry;
+    }
+
+    route.leg_summaries = route.legs.map((leg: any) => leg.summary);
+
+    // Collect all unique admins across all legs of this route
+    const routeUniqueIsoCodes = new Set<string>();
+
+    // Collect all unique notification messages across all legs of this route
+    const routeUniqueNotificationMessages = new Set<string>();
+
+    // Collect all incidents across all legs of this route
+    const routeIncidents: any[] = [];
+
+    // Collect voice instruction announcements from all steps
+    const routeAnnouncements: string[] = [];
+
+    let totalDistanceWeightedSpeed = 0; // Sum of (speed × distance) for each segment
+    let sumDistanceMeters = 0;
+
+    // Object to track distance by congestion type
+    const congestionTypeToDistance = {
+      severe: 0,
+      heavy: 0,
+      moderate: 0,
+      low: 0
+    };
+
+    route.legs.forEach((leg: any) => {
+      if (leg.annotation && leg.annotation.speed && leg.annotation.distance) {
+        leg.annotation.speed.forEach((speed: number, index: number) => {
+          const speedValue = parseFloat(String(speed));
+          const distance = parseFloat(String(leg.annotation.distance[index]));
+          // Calculate the weighted speed (speed * distance)
+          totalDistanceWeightedSpeed += speedValue * distance;
+          sumDistanceMeters += distance;
+        });
+      }
+
+      if (
+        leg.annotation &&
+        leg.annotation.congestion &&
+        leg.annotation.distance
+      ) {
+        // iterate every congestion string in leg.annotation.congestion
+        // each string is one of `severe, heavy, moderate, low, unknown`
+        // keep track of total distance by type of congestion
+        leg.annotation.congestion.forEach(
+          (congestion: string, index: number) => {
+            const distance = parseFloat(String(leg.annotation.distance[index]));
+            if (
+              congestion === 'severe' ||
+              congestion === 'heavy' ||
+              congestion === 'moderate' ||
+              congestion === 'low'
+            ) {
+              congestionTypeToDistance[congestion] += distance;
+            }
+            // Skip 'unknown' congestion type
+          }
+        );
+      }
+
+      if (leg.admins && Array.isArray(leg.admins)) {
+        // Extract unique ISO codes from this leg
+        leg.admins.forEach((admin: any) => {
+          if (admin.iso_3166_1_alpha3) {
+            routeUniqueIsoCodes.add(admin.iso_3166_1_alpha3);
+          }
+        });
+      }
+
+      // Process notifications if they exist
+      if (leg.notifications && Array.isArray(leg.notifications)) {
+        // Extract unique notification messages from this leg
+        leg.notifications.forEach((notification: any) => {
+          if (notification.details && notification.details.message) {
+            routeUniqueNotificationMessages.add(notification.details.message);
+          }
+        });
+      }
+
+      // Process incidents if they exist
+      if (leg.incidents && Array.isArray(leg.incidents)) {
+        leg.incidents.forEach((incident: any) => {
+          // Extract only the specified fields for each incident
+          routeIncidents.push({
+            type: incident.type,
+            end_time: incident.end_time,
+            long_description: incident.long_description,
+            impact: incident.impact,
+            affected_road_names: incident.affected_road_names,
+            length: incident.length
+          });
+        });
+      }
+
+      // Process steps if they exist to collect voice instructions
+      if (leg.steps && Array.isArray(leg.steps)) {
+        leg.steps.forEach((step: any) => {
+          if (step.voiceInstructions && Array.isArray(step.voiceInstructions)) {
+            step.voiceInstructions.forEach((instruction: any) => {
+              if (instruction.announcement) {
+                routeAnnouncements.push(instruction.announcement);
+              }
+            });
+          }
+        });
+      }
+    }); // Add all unique admins as a new property on the route
+    route.intersecting_admins = Array.from(routeUniqueIsoCodes);
+
+    // Add all unique notification messages as a new property on the route
+    route.notifications_summary = Array.from(routeUniqueNotificationMessages);
+
+    // Add all incidents with the specified fields as a new property on the route
+    route.incidents_summary = routeIncidents;
+
+    // Add voice instruction announcements only if there are 1 to 10 of them
+    // If there are more than 10, it's just too many, and if there is 0 then we don't have them.
+    if (routeAnnouncements.length >= 1 && routeAnnouncements.length <= 10) {
+      route.instructions = routeAnnouncements;
+    }
+
+    route.num_legs = route.legs.length;
+
+    // Add congestion distance information to route
+    route.congestion_information = {
+      length_low: Math.round(congestionTypeToDistance.low),
+      length_moderate: Math.round(congestionTypeToDistance.moderate),
+      length_heavy: Math.round(congestionTypeToDistance.heavy),
+      length_severe: Math.round(congestionTypeToDistance.severe)
+    };
+
+    // Calculate and add average speed in km/h
+    if (sumDistanceMeters > 0 && totalDistanceWeightedSpeed > 0) {
+      // Calculate distance-weighted average speed
+      const averageMetersPerSecond =
+        totalDistanceWeightedSpeed / sumDistanceMeters;
+      // Convert m/s to km/h (multiply by 3.6) and round to integer
+      route.average_speed_kph = Math.round(averageMetersPerSecond * 3.6);
+    }
+
+    if (route.duration_typical) {
+      route.duration_under_typical_traffic_conditions = Math.round(
+        route.duration_typical
+      );
+      delete route.duration_typical;
+    }
+
+    if (route.weight_typical) {
+      delete route.weight_typical;
+    }
+
+    delete route.legs;
+  });
+
+  return data;
+}

--- a/src/tools/directions-tool/formatIsoDateTime.test.ts
+++ b/src/tools/directions-tool/formatIsoDateTime.test.ts
@@ -1,0 +1,35 @@
+import { formatIsoDateTime } from './formatIsoDateTime';
+
+describe('formatIsoDateTime', () => {
+  it('converts YYYY-MM-DDThh:mm:ss to YYYY-MM-DDThh:mm by removing seconds', () => {
+    const input = '2025-06-05T10:30:45';
+    const expected = '2025-06-05T10:30';
+
+    expect(formatIsoDateTime(input)).toBe(expected);
+  });
+
+  it('leaves YYYY-MM-DDThh:mm:ssZ format unchanged', () => {
+    const input = '2025-06-05T10:30:45Z';
+
+    expect(formatIsoDateTime(input)).toBe(input);
+  });
+
+  it('leaves YYYY-MM-DDThh:mm:ss±hh:mm format unchanged', () => {
+    const input = '2025-06-05T10:30:45+02:00';
+
+    expect(formatIsoDateTime(input)).toBe(input);
+  });
+
+  it('leaves YYYY-MM-DDThh:mm format unchanged', () => {
+    const input = '2025-06-05T10:30';
+
+    expect(formatIsoDateTime(input)).toBe(input);
+  });
+
+  it('handles edge cases with zeros in seconds', () => {
+    const input = '2025-06-05T10:30:00';
+    const expected = '2025-06-05T10:30';
+
+    expect(formatIsoDateTime(input)).toBe(expected);
+  });
+});

--- a/src/tools/directions-tool/formatIsoDateTime.ts
+++ b/src/tools/directions-tool/formatIsoDateTime.ts
@@ -1,0 +1,18 @@
+/**
+ * Helper function to format ISO datetime strings according to Mapbox API requirements.
+ * It converts the format YYYY-MM-DDThh:mm:ss (with seconds but no timezone) to
+ * YYYY-MM-DDThh:mm (no seconds, no timezone) by removing the seconds part.
+ * Other valid formats are left unchanged.
+ */
+export const formatIsoDateTime = (dateTime: string): string => {
+  // Regex for matching YYYY-MM-DDThh:mm:ss format (with seconds but no timezone)
+  const dateWithSecondsNoTz = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/;
+
+  if (dateWithSecondsNoTz.test(dateTime)) {
+    // Extract up to the minutes part only, dropping the seconds
+    return dateTime.substring(0, dateTime.lastIndexOf(':'));
+  }
+
+  // Return unchanged if it's already in a valid format
+  return dateTime;
+};


### PR DESCRIPTION
## Description

Directions responses can be pretty large, especially for routes >100km.
After reviewing hows agents interact with the tool I reached a conclusion that the directions tool might be unnecessary verbose. So in this PR I am removing some params (like walking speed, walking pathway preference and making geometry a choice of either `none` or `geojson` since I did not see agents even attempt to use `polyline` format). Additionally, I am processing responses to remove or summarise information into a much smaller json.

I notice that geometry is often not necessary in a scenario where agent wants to check distance or ETA. In such cases geometry can now be omitted (this PR makes it optional with default value of `none`).

Lastly, I noticed that directions tool can have 3 different time formats used for arrive_by and depart_at settings, but sometimes agents get confused and use a wrong format that can be easily converted into valid format, so I made changes to adjust formats when possible. 


---

## Testing

- Unit tests
- Testing with Claude desktop and Smolagents scripts with GPT
- I observe ~90% reduction in number of tokens returned from the tool with no degradation in agent's responses to a small benchmark of prompts. In cases where geometry is not requested the response sizes are over 99% smaller since geometry used to be one of the biggest parts of the response.
- Additional bonus of smaller responses is that agents also become a little bit faster due to fewer tokens being sent across network and churned through the LLMs, but it's hard to provide a number because it all depends on prompt, context, model, api and even time of day

---

## Checklist

- [x] Code has been tested locally
- [x] Unit tests have been added or updated
- [x] Documentation has been updated if needed

---

## Additional Notes

n/a