### PR TITLE
Release to NPM using CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,10 @@ workflows:
     jobs:
       - build:
           filters:
+            branches:
+              ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v.*/
       - publish:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,87 @@
+version: 2.1
+
+workflows:
+  version: 2
+  build-and-publish:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - publish:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v(?!.*-dev).*/
+      - publish-dev:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*-dev.*/
+
+jobs:
+  build:
+    docker:
+      - image: cimg/node:22.0
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package-lock.json" }}
+            - v1-dependencies-
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
+      - run:
+          name: Run linting
+          command: npm run lint
+      - run:
+          name: Run tests
+          command: npm test
+      - run:
+          name: Build
+          command: npm run build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+            - package.json
+            - package-lock.json
+
+  publish:
+    docker:
+      - image: cimg/node:22.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run:
+          name: Publish package
+          command: npm publish --access public
+
+  publish-dev:
+    docker:
+      - image: cimg/node:22.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run:
+          name: Publish dev package
+          command: npm publish --tag dev --access public


### PR DESCRIPTION
## Description

CircleCI configuration for NPM releases. There are two jobs in the configuration:
- Production release: publishes a release if there is a tag matching the pattern `vX.X.X`
- Development release: publishes a development release if there is a tag matching the pattern `vX.X.X-dev`

---

## Testing

<!-- Include logs, screenshots, terminal output, or any relevant proof of successful testing. -->

---

## Checklist

- [ ] Code has been tested locally
- [ ] Unit tests have been added or updated
- [ ] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
