### PR TITLE
updated mcp server references to is_error to use isError in its place

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mcp-server",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mcp-server",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/plop-templates/tool.test.hbs
+++ b/plop-templates/tool.test.hbs
@@ -21,7 +21,7 @@ describe('{{pascalCase name}}Tool', () => {
 
     const result = await new {{pascalCase name}}Tool().run({...});
 
-    expect(result.is_error).toBe(true);
+    expect(result.isError).toBe(true);
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: 'Internal error has occurred.'

--- a/src/tools/MapboxApiBasedTool.test.ts
+++ b/src/tools/MapboxApiBasedTool.test.ts
@@ -63,7 +63,7 @@ describe('MapboxApiBasedTool', () => {
         const result = await toolWithInvalidToken.run({ testParam: 'test' });
 
         // Verify the error response
-        expect(result.is_error).toBe(true);
+        expect(result.isError).toBe(true);
 
         // Check for error message content
         if (process.env.VERBOSE_ERRORS === 'true') {
@@ -98,7 +98,7 @@ describe('MapboxApiBasedTool', () => {
       const result = await testTool.run({ testParam: 'test' });
 
       // The token validation should pass, and we should get the success result
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       expect(result.content[0]).toHaveProperty('type', 'text');
       expect(
         JSON.parse((result.content[0] as { type: 'text'; text: string }).text)
@@ -114,7 +114,7 @@ describe('MapboxApiBasedTool', () => {
       const result = await testTool.run({ testParam: 'test' });
 
       // Verify the response contains the generic error message
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
       expect(result.content).toHaveLength(1);
       expect(result.content[0]).toMatchObject({
         type: 'text',
@@ -135,7 +135,7 @@ describe('MapboxApiBasedTool', () => {
       const result = await testTool.run({ testParam: 'test' });
 
       // Verify the response contains the actual error message
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
       expect(result.content).toHaveLength(1);
       expect(result.content[0]).toMatchObject({
         type: 'text',
@@ -156,7 +156,7 @@ describe('MapboxApiBasedTool', () => {
       const result = await testTool.run({ testParam: 'test' });
 
       // Verify the response contains the generic error message
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
       expect(result.content).toHaveLength(1);
       expect(result.content[0]).toMatchObject({
         type: 'text',
@@ -181,7 +181,7 @@ describe('MapboxApiBasedTool', () => {
       const result = await testTool.run({ testParam: 'test' });
 
       // Verify the response contains the string error
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
       expect(result.content).toHaveLength(1);
       expect(result.content[0]).toMatchObject({
         type: 'text',

--- a/src/tools/MapboxApiBasedTool.ts
+++ b/src/tools/MapboxApiBasedTool.ts
@@ -18,7 +18,7 @@ export const OutputSchema = z.object({
       })
     ])
   ),
-  is_error: z.boolean().default(false)
+  isError: z.boolean().default(false)
 });
 
 export abstract class MapboxApiBasedTool<InputSchema extends ZodTypeAny> {
@@ -76,14 +76,14 @@ export abstract class MapboxApiBasedTool<InputSchema extends ZodTypeAny> {
       ) {
         return {
           content: [result],
-          is_error: false
+          isError: false
         };
       }
 
       // Otherwise return as text
       return {
         content: [{ type: 'text', text: JSON.stringify(result) }],
-        is_error: false
+        isError: false
       };
     } catch (error) {
       const errorMessage =
@@ -105,7 +105,7 @@ export abstract class MapboxApiBasedTool<InputSchema extends ZodTypeAny> {
               : 'Internal error has occurred.'
           }
         ],
-        is_error: true
+        isError: true
       };
     }
   }

--- a/src/tools/category-search-tool/CategorySearchTool.test.ts
+++ b/src/tools/category-search-tool/CategorySearchTool.test.ts
@@ -133,7 +133,7 @@ describe('CategorySearchTool', () => {
       category: 'restaurant'
     });
 
-    expect(result.is_error).toBe(true);
+    expect(result.isError).toBe(true);
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: 'Internal error has occurred.'
@@ -150,7 +150,7 @@ describe('CategorySearchTool', () => {
         limit: 26
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test limit too low
@@ -160,7 +160,7 @@ describe('CategorySearchTool', () => {
         limit: 0
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -174,7 +174,7 @@ describe('CategorySearchTool', () => {
         proximity: { longitude: -181, latitude: 40 }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test invalid latitude in bbox
@@ -189,7 +189,7 @@ describe('CategorySearchTool', () => {
         }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -232,7 +232,7 @@ describe('CategorySearchTool', () => {
       category: 'cafe'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
@@ -271,7 +271,7 @@ describe('CategorySearchTool', () => {
       category: 'fast_food'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -320,7 +320,7 @@ describe('CategorySearchTool', () => {
       limit: 2
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -344,7 +344,7 @@ describe('CategorySearchTool', () => {
       category: 'nonexistent_category'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
     expect((result.content[0] as { type: 'text'; text: string }).text).toBe(
       'No results found.'
@@ -376,7 +376,7 @@ describe('CategorySearchTool', () => {
       category: 'gas_station'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -412,7 +412,7 @@ describe('CategorySearchTool', () => {
       format: 'json_string'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
 
     const jsonContent = (result.content[0] as { type: 'text'; text: string })
@@ -445,7 +445,7 @@ describe('CategorySearchTool', () => {
       category: 'cafe'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
     expect(
       (result.content[0] as { type: 'text'; text: string }).text

--- a/src/tools/directions-tool/DirectionsTool.test.ts
+++ b/src/tools/directions-tool/DirectionsTool.test.ts
@@ -158,7 +158,7 @@ describe('DirectionsTool', () => {
       ]
     });
 
-    expect(result.is_error).toBe(true);
+    expect(result.isError).toBe(true);
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: 'Request failed with status 404: Not Found'
@@ -175,7 +175,7 @@ describe('DirectionsTool', () => {
         coordinates: [[-73.989, 40.733]]
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test with zero coordinates (invalid)
@@ -184,7 +184,7 @@ describe('DirectionsTool', () => {
         coordinates: []
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -199,7 +199,7 @@ describe('DirectionsTool', () => {
         coordinates: tooManyCoords
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -259,7 +259,7 @@ describe('DirectionsTool', () => {
           exclude: 'toll,motorway,unpaved'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Test with driving-traffic profile
@@ -273,7 +273,7 @@ describe('DirectionsTool', () => {
           exclude: 'tunnel,country_border,state_border'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
     });
 
@@ -291,7 +291,7 @@ describe('DirectionsTool', () => {
           exclude: 'toll'
         })
       ).resolves.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Test with cycling profile
@@ -305,7 +305,7 @@ describe('DirectionsTool', () => {
           exclude: 'motorway'
         })
       ).resolves.toMatchObject({
-        is_error: true
+        isError: true
       });
     });
 
@@ -324,7 +324,7 @@ describe('DirectionsTool', () => {
           exclude: 'ferry'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Test with walking profile
@@ -338,7 +338,7 @@ describe('DirectionsTool', () => {
           exclude: 'ferry'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Test with cycling profile
@@ -352,7 +352,7 @@ describe('DirectionsTool', () => {
           exclude: 'cash_only_tolls'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
     });
 
@@ -371,7 +371,7 @@ describe('DirectionsTool', () => {
           exclude: 'point(-73.95 40.75)'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Test with walking profile - should fail
@@ -385,7 +385,7 @@ describe('DirectionsTool', () => {
           exclude: 'point(-73.95 40.75)'
         })
       ).resolves.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Test with cycling profile - should fail
@@ -399,7 +399,7 @@ describe('DirectionsTool', () => {
           exclude: 'point(-73.95 40.75)'
         })
       ).resolves.toMatchObject({
-        is_error: true
+        isError: true
       });
     });
 
@@ -418,7 +418,7 @@ describe('DirectionsTool', () => {
           exclude: 'toll,motorway,ferry,cash_only_tolls,point(-73.95 40.75)'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Mixed valid and invalid exclusions (ferry is valid for walking, toll is not)
@@ -432,7 +432,7 @@ describe('DirectionsTool', () => {
           exclude: 'ferry,toll'
         })
       ).resolves.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // All valid exclusions for cycling profile
@@ -446,7 +446,7 @@ describe('DirectionsTool', () => {
           exclude: 'ferry,cash_only_tolls'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
     });
   });
@@ -468,7 +468,7 @@ describe('DirectionsTool', () => {
           depart_at: validDateTime
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       const calledUrlDriving = mockFetch.mock.calls[0][0];
@@ -487,7 +487,7 @@ describe('DirectionsTool', () => {
           depart_at: validDateTime
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       const calledUrlTraffic = mockFetch.mock.calls[1][0];
@@ -514,7 +514,7 @@ describe('DirectionsTool', () => {
             max_weight: 7.8
           })
         ).resolves.not.toMatchObject({
-          is_error: true
+          isError: true
         });
 
         const calledUrlDriving = mockFetch.mock.calls[0][0];
@@ -533,7 +533,7 @@ describe('DirectionsTool', () => {
             max_height: 3.2
           })
         ).resolves.not.toMatchObject({
-          is_error: true
+          isError: true
         });
 
         const calledUrlTraffic = mockFetch.mock.calls[1][0];
@@ -554,7 +554,7 @@ describe('DirectionsTool', () => {
             max_height: 4.5
           })
         ).resolves.toMatchObject({
-          is_error: true
+          isError: true
         });
 
         // Test with cycling profile
@@ -568,7 +568,7 @@ describe('DirectionsTool', () => {
             max_width: 2.0
           })
         ).resolves.toMatchObject({
-          is_error: true
+          isError: true
         });
       });
 
@@ -586,7 +586,7 @@ describe('DirectionsTool', () => {
             max_height: 15.0
           })
         ).resolves.toMatchObject({
-          is_error: true
+          isError: true
         });
 
         // Test invalid width (negative)
@@ -600,7 +600,7 @@ describe('DirectionsTool', () => {
             max_width: -1.0
           })
         ).resolves.toMatchObject({
-          is_error: true
+          isError: true
         });
 
         // Test invalid weight (too heavy)
@@ -614,7 +614,7 @@ describe('DirectionsTool', () => {
             max_weight: 150.0
           })
         ).resolves.toMatchObject({
-          is_error: true
+          isError: true
         });
       });
     });
@@ -634,7 +634,7 @@ describe('DirectionsTool', () => {
           depart_at: validDateTime
         })
       ).resolves.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Test with cycling profile
@@ -648,7 +648,7 @@ describe('DirectionsTool', () => {
           depart_at: validDateTime
         })
       ).resolves.toMatchObject({
-        is_error: true
+        isError: true
       });
     });
 
@@ -667,7 +667,7 @@ describe('DirectionsTool', () => {
           depart_at: '2025-06-05T10:30:00Z'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Format 2: YYYY-MM-DDThh:mmss±hh:mm
@@ -677,7 +677,7 @@ describe('DirectionsTool', () => {
           depart_at: '2025-06-05T10:30:00+02:00'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Format 3: YYYY-MM-DDThh:mm
@@ -687,7 +687,7 @@ describe('DirectionsTool', () => {
           depart_at: '2025-06-05T10:30'
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
     });
 
@@ -719,7 +719,7 @@ describe('DirectionsTool', () => {
           depart_at: format
         });
 
-        expect(result.is_error).toBe(true);
+        expect(result.isError).toBe(true);
       }
     });
 
@@ -746,7 +746,7 @@ describe('DirectionsTool', () => {
             depart_at: date
           })
         ).resolves.toMatchObject({
-          is_error: true
+          isError: true
         });
       }
     });
@@ -767,7 +767,7 @@ describe('DirectionsTool', () => {
           depart_at: dateTimeWithSeconds
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Verify the seconds were stripped in the API call
@@ -797,7 +797,7 @@ describe('DirectionsTool', () => {
           arrive_by: dateTimeWithSeconds
         })
       ).resolves.not.toMatchObject({
-        is_error: true
+        isError: true
       });
 
       // Verify the seconds were stripped in the API call
@@ -846,7 +846,7 @@ describe('DirectionsTool', () => {
         arrive_by: validDateTime
       });
 
-      expect(result1.is_error).toBe(true);
+      expect(result1.isError).toBe(true);
 
       // Test with walking profile
       const result2 = await new DirectionsTool().run({
@@ -858,7 +858,7 @@ describe('DirectionsTool', () => {
         arrive_by: validDateTime
       });
 
-      expect(result2.is_error).toBe(true);
+      expect(result2.isError).toBe(true);
 
       // Test with cycling profile
       const result3 = await new DirectionsTool().run({
@@ -870,7 +870,7 @@ describe('DirectionsTool', () => {
         arrive_by: validDateTime
       });
 
-      expect(result3.is_error).toBe(true);
+      expect(result3.isError).toBe(true);
     });
 
     it('rejects when both arrive_by and depart_at are provided', async () => {
@@ -884,7 +884,7 @@ describe('DirectionsTool', () => {
         arrive_by: '2025-06-05T10:30:00Z'
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
     });
 
     it('accepts valid ISO 8601 formats for arrive_by', async () => {
@@ -959,7 +959,7 @@ describe('DirectionsTool', () => {
           arrive_by: format
         });
 
-        expect(result.is_error).toBe(true);
+        expect(result.isError).toBe(true);
       }
     });
 
@@ -983,7 +983,7 @@ describe('DirectionsTool', () => {
           arrive_by: date
         });
 
-        expect(result.is_error).toBe(true);
+        expect(result.isError).toBe(true);
       }
     });
   });
@@ -1001,7 +1001,7 @@ describe('DirectionsTool', () => {
         geometries: 'none'
       })
     ).resolves.not.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     await expect(
@@ -1013,7 +1013,7 @@ describe('DirectionsTool', () => {
         geometries: 'geojson'
       })
     ).resolves.not.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Invalid values: 'polyline' and 'polyline6' were removed
@@ -1028,7 +1028,7 @@ describe('DirectionsTool', () => {
         geometries: 'polyline'
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     await expect(
@@ -1041,7 +1041,7 @@ describe('DirectionsTool', () => {
         geometries: 'polyline6'
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 });

--- a/src/tools/forward-geocode-tool/ForwardGeocodeTool.test.ts
+++ b/src/tools/forward-geocode-tool/ForwardGeocodeTool.test.ts
@@ -137,7 +137,7 @@ describe('ForwardGeocodeTool', () => {
       q: 'test query'
     });
 
-    expect(result.is_error).toBe(true);
+    expect(result.isError).toBe(true);
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: 'Internal error has occurred.'
@@ -152,7 +152,7 @@ describe('ForwardGeocodeTool', () => {
         q: 'test; query'
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -165,7 +165,7 @@ describe('ForwardGeocodeTool', () => {
         q: longQuery
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -178,7 +178,7 @@ describe('ForwardGeocodeTool', () => {
         q: longQuery
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -192,7 +192,7 @@ describe('ForwardGeocodeTool', () => {
         limit: 11
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test limit too low
@@ -202,7 +202,7 @@ describe('ForwardGeocodeTool', () => {
         limit: 0
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -216,7 +216,7 @@ describe('ForwardGeocodeTool', () => {
         proximity: { longitude: -181, latitude: 40 }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test invalid latitude in bbox
@@ -231,7 +231,7 @@ describe('ForwardGeocodeTool', () => {
         }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -293,7 +293,7 @@ describe('ForwardGeocodeTool', () => {
       q: 'Seattle'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
@@ -333,7 +333,7 @@ describe('ForwardGeocodeTool', () => {
       q: 'NYC'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -382,7 +382,7 @@ describe('ForwardGeocodeTool', () => {
       limit: 2
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -406,7 +406,7 @@ describe('ForwardGeocodeTool', () => {
       q: 'nonexistentplace12345'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
     expect((result.content[0] as { type: 'text'; text: string }).text).toBe(
       'No results found.'
@@ -438,7 +438,7 @@ describe('ForwardGeocodeTool', () => {
       q: 'Some Place'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -474,7 +474,7 @@ describe('ForwardGeocodeTool', () => {
       format: 'json_string'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
 
     const jsonContent = (result.content[0] as { type: 'text'; text: string })
@@ -507,7 +507,7 @@ describe('ForwardGeocodeTool', () => {
       q: 'Test City'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
     expect(
       (result.content[0] as { type: 'text'; text: string }).text

--- a/src/tools/matrix-tool/MatrixTool.test.ts
+++ b/src/tools/matrix-tool/MatrixTool.test.ts
@@ -95,7 +95,7 @@ describe('MatrixTool', () => {
       profile: 'driving'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
     // Check that URL contains correct profile and coordinates
@@ -228,7 +228,7 @@ describe('MatrixTool', () => {
       sources: '1'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     const url = mockFetch.mock.calls[0][0];
     expect(url).toContain('annotations=distance%2Cduration');
     expect(url).toContain('approaches=curb%3Bunrestricted%3Bcurb');
@@ -253,7 +253,7 @@ describe('MatrixTool', () => {
       profile: 'walking'
     });
 
-    expect(result.is_error).toBe(true);
+    expect(result.isError).toBe(true);
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: 'Internal error has occurred.'
@@ -273,7 +273,7 @@ describe('MatrixTool', () => {
       profile: 'driving-traffic'
     });
 
-    expect(result.is_error).toBe(true);
+    expect(result.isError).toBe(true);
     expect(mockFetch).not.toHaveBeenCalled();
 
     // Test for specific error message by calling execute directly
@@ -302,7 +302,7 @@ describe('MatrixTool', () => {
         profile: 'driving'
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error message using Zod validation from schema
       await expect(async () => {
@@ -323,7 +323,7 @@ describe('MatrixTool', () => {
         profile: 'driving'
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error message using Zod validation from schema
       await expect(async () => {
@@ -344,7 +344,7 @@ describe('MatrixTool', () => {
         ],
         profile: 'driving'
       });
-      expect(invalidLongitude.is_error).toBe(true);
+      expect(invalidLongitude.isError).toBe(true);
 
       // Test longitude bounds error message
       await expect(async () => {
@@ -364,7 +364,7 @@ describe('MatrixTool', () => {
         ],
         profile: 'driving'
       });
-      expect(invalidLatitude.is_error).toBe(true);
+      expect(invalidLatitude.isError).toBe(true);
 
       // Test latitude bounds error message
       await expect(async () => {
@@ -389,7 +389,7 @@ describe('MatrixTool', () => {
         approaches: 'curb;unrestricted' // Only 2 for 3 coordinates
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error for approaches length mismatch
       await expect(async () => {
@@ -417,7 +417,7 @@ describe('MatrixTool', () => {
         approaches: 'curb;invalid' // 'invalid' is not allowed
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error for invalid approach value
       await expect(async () => {
@@ -445,7 +445,7 @@ describe('MatrixTool', () => {
         bearings: '45,90;120,45' // Only 2 for 3 coordinates
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error for bearings length mismatch
       await expect(async () => {
@@ -473,7 +473,7 @@ describe('MatrixTool', () => {
         bearings: '45,90;invalid'
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error for invalid bearing format
       await expect(async () => {
@@ -498,7 +498,7 @@ describe('MatrixTool', () => {
         bearings: '400,90;120,45' // 400 is > 360
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error for invalid bearing angle
       await expect(async () => {
@@ -523,7 +523,7 @@ describe('MatrixTool', () => {
         bearings: '45,200;120,45' // 200 is > 180
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error for invalid bearing degrees
       await expect(async () => {
@@ -548,7 +548,7 @@ describe('MatrixTool', () => {
         sources: '0;2' // 2 is out of bounds
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error message for invalid sources indices
       await expect(async () => {
@@ -575,7 +575,7 @@ describe('MatrixTool', () => {
         destinations: '3' // 3 is out of bounds
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error message for invalid destinations indices
       await expect(async () => {
@@ -602,7 +602,7 @@ describe('MatrixTool', () => {
         destinations: '-1'
       });
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
 
       // Test direct error message for invalid destinations indices
       await expect(async () => {
@@ -677,7 +677,7 @@ describe('MatrixTool', () => {
         approaches: 'curb;;unrestricted'
       });
 
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       const url = mockFetch.mock.calls[0][0];
       expect(url).toContain('approaches=curb%3B%3Bunrestricted');
     });
@@ -697,7 +697,7 @@ describe('MatrixTool', () => {
         bearings: '45,90;;120,45'
       });
 
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       const url = mockFetch.mock.calls[0][0];
       expect(url).toContain('bearings=45%2C90%3B%3B120%2C45');
     });
@@ -717,7 +717,7 @@ describe('MatrixTool', () => {
         approaches: 'curb;;unrestricted'
       });
 
-      expect(resultWithSuccess1.is_error).toBe(false);
+      expect(resultWithSuccess1.isError).toBe(false);
 
       const resultWithSuccess2 = await tool.run({
         coordinates: [
@@ -728,7 +728,7 @@ describe('MatrixTool', () => {
         approaches: 'curb;'
       });
 
-      expect(resultWithSuccess2.is_error).toBe(false);
+      expect(resultWithSuccess2.isError).toBe(false);
     });
 
     it('rejects sources and destinations with unused coordinates', async () => {
@@ -745,7 +745,7 @@ describe('MatrixTool', () => {
         sources: '1',
         destinations: '2'
       });
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
       expect(mockFetch).not.toHaveBeenCalled();
 
       // Test direct error message for unused coordinates
@@ -836,7 +836,7 @@ describe('MatrixTool', () => {
         coordinates,
         profile: 'driving'
       });
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       expect(mockFetch).toHaveBeenCalled();
     });
 
@@ -855,7 +855,7 @@ describe('MatrixTool', () => {
         coordinates,
         profile: 'driving-traffic'
       });
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       expect(mockFetch).toHaveBeenCalled();
     });
 
@@ -872,7 +872,7 @@ describe('MatrixTool', () => {
         coordinates,
         profile: 'driving-traffic'
       });
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
       expect(mockFetch).not.toHaveBeenCalled();
 
       // Test direct error message for exceeding coordinate limit
@@ -908,7 +908,7 @@ describe('MatrixTool', () => {
         profile: 'driving-traffic'
       });
 
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       const url = mockFetch.mock.calls[0][0];
       expect(url).toContain('directions-matrix/v1/mapbox/driving-traffic');
     });
@@ -926,7 +926,7 @@ describe('MatrixTool', () => {
         profile: 'driving'
       });
 
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       const url = mockFetch.mock.calls[0][0];
       expect(url).toContain('directions-matrix/v1/mapbox/driving');
     });
@@ -944,7 +944,7 @@ describe('MatrixTool', () => {
         profile: 'walking'
       });
 
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       const url = mockFetch.mock.calls[0][0];
       expect(url).toContain('directions-matrix/v1/mapbox/walking');
     });
@@ -962,7 +962,7 @@ describe('MatrixTool', () => {
         profile: 'cycling'
       });
 
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       const url = mockFetch.mock.calls[0][0];
       expect(url).toContain('directions-matrix/v1/mapbox/cycling');
     });

--- a/src/tools/poi-search-tool/PoiSearchTool.test.ts
+++ b/src/tools/poi-search-tool/PoiSearchTool.test.ts
@@ -144,7 +144,7 @@ describe('PoiSearchTool', () => {
       q: 'test query'
     });
 
-    expect(result.is_error).toBe(true);
+    expect(result.isError).toBe(true);
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: 'Internal error has occurred.'
@@ -160,7 +160,7 @@ describe('PoiSearchTool', () => {
         q: longQuery
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -174,7 +174,7 @@ describe('PoiSearchTool', () => {
         limit: 11
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test limit too low
@@ -184,7 +184,7 @@ describe('PoiSearchTool', () => {
         limit: 0
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -198,7 +198,7 @@ describe('PoiSearchTool', () => {
         proximity: { longitude: -181, latitude: 40 }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test invalid latitude in bbox
@@ -213,7 +213,7 @@ describe('PoiSearchTool', () => {
         }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -291,7 +291,7 @@ describe('PoiSearchTool', () => {
       q: 'Starbucks'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
@@ -330,7 +330,7 @@ describe('PoiSearchTool', () => {
       q: 'Central Park'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -379,7 +379,7 @@ describe('PoiSearchTool', () => {
       limit: 2
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -403,7 +403,7 @@ describe('PoiSearchTool', () => {
       q: 'NonexistentPlace'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
     expect((result.content[0] as { type: 'text'; text: string }).text).toBe(
       'No results found.'
@@ -435,7 +435,7 @@ describe('PoiSearchTool', () => {
       q: 'location'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -471,7 +471,7 @@ describe('PoiSearchTool', () => {
       format: 'json_string'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
 
     const jsonContent = (result.content[0] as { type: 'text'; text: string })
@@ -504,7 +504,7 @@ describe('PoiSearchTool', () => {
       q: 'Test Place'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
     expect(
       (result.content[0] as { type: 'text'; text: string }).text

--- a/src/tools/reverse-geocode-tool/ReverseGeocodeTool.test.ts
+++ b/src/tools/reverse-geocode-tool/ReverseGeocodeTool.test.ts
@@ -89,7 +89,7 @@ describe('ReverseGeocodeTool', () => {
         limit: 6
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test limit too low
@@ -100,7 +100,7 @@ describe('ReverseGeocodeTool', () => {
         limit: 0
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -114,7 +114,7 @@ describe('ReverseGeocodeTool', () => {
         latitude: 40.733
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     await expect(
@@ -123,7 +123,7 @@ describe('ReverseGeocodeTool', () => {
         latitude: 40.733
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test invalid latitude
@@ -133,7 +133,7 @@ describe('ReverseGeocodeTool', () => {
         latitude: 91
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     await expect(
@@ -142,7 +142,7 @@ describe('ReverseGeocodeTool', () => {
         latitude: -91
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -167,7 +167,7 @@ describe('ReverseGeocodeTool', () => {
         limit: 3
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Should fail with multiple types when limit > 1
@@ -179,7 +179,7 @@ describe('ReverseGeocodeTool', () => {
         types: ['address', 'place']
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -216,7 +216,7 @@ describe('ReverseGeocodeTool', () => {
       latitude: 40.733
     });
 
-    expect(result.is_error).toBe(true);
+    expect(result.isError).toBe(true);
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: 'Internal error has occurred.'
@@ -234,7 +234,7 @@ describe('ReverseGeocodeTool', () => {
         country: ['USA'] // Should be 2 characters
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -266,7 +266,7 @@ describe('ReverseGeocodeTool', () => {
       latitude: 40.733
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
@@ -307,7 +307,7 @@ describe('ReverseGeocodeTool', () => {
       latitude: 40.776
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -360,7 +360,7 @@ describe('ReverseGeocodeTool', () => {
       types: ['address']
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -389,7 +389,7 @@ describe('ReverseGeocodeTool', () => {
       latitude: 0.0
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
     expect((result.content[0] as { type: 'text'; text: string }).text).toBe(
       'No results found.'
@@ -422,7 +422,7 @@ describe('ReverseGeocodeTool', () => {
       latitude: 35.456
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
 
     const textContent = (result.content[0] as { type: 'text'; text: string })
       .text;
@@ -459,7 +459,7 @@ describe('ReverseGeocodeTool', () => {
       format: 'json_string'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
 
     const jsonContent = (result.content[0] as { type: 'text'; text: string })
@@ -493,7 +493,7 @@ describe('ReverseGeocodeTool', () => {
       latitude: 45.515
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
     expect(
       (result.content[0] as { type: 'text'; text: string }).text

--- a/src/tools/static-map-image-tool/StaticMapImageTool.test.ts
+++ b/src/tools/static-map-image-tool/StaticMapImageTool.test.ts
@@ -44,7 +44,7 @@ describe('StaticMapImageTool', () => {
       style: 'mapbox/satellite-v9'
     });
 
-    expect(result.is_error).toBe(false);
+    expect(result.isError).toBe(false);
     expect(result.content).toHaveLength(1);
     expect(result.content[0]).toMatchObject({
       type: 'image',
@@ -96,7 +96,7 @@ describe('StaticMapImageTool', () => {
       size: { width: 600, height: 400 }
     });
 
-    expect(result.is_error).toBe(true);
+    expect(result.isError).toBe(true);
     expect(result.content[0]).toMatchObject({
       type: 'text',
       text: 'Internal error has occurred.'
@@ -114,7 +114,7 @@ describe('StaticMapImageTool', () => {
         size: { width: 600, height: 400 }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test invalid latitude
@@ -125,7 +125,7 @@ describe('StaticMapImageTool', () => {
         size: { width: 600, height: 400 }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 
@@ -140,7 +140,7 @@ describe('StaticMapImageTool', () => {
         size: { width: 1281, height: 600 }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
 
     // Test size too small
@@ -151,7 +151,7 @@ describe('StaticMapImageTool', () => {
         size: { width: 0, height: 600 }
       })
     ).resolves.toMatchObject({
-      is_error: true
+      isError: true
     });
   });
 

--- a/src/tools/version-tool/VersionTool.test.ts
+++ b/src/tools/version-tool/VersionTool.test.ts
@@ -26,7 +26,7 @@ describe('VersionTool', () => {
     it('should return version information', async () => {
       const result = await tool.run({});
 
-      expect(result.is_error).toBe(false);
+      expect(result.isError).toBe(false);
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toContain('Test MCP Server');
@@ -43,7 +43,7 @@ describe('VersionTool', () => {
 
       const result = await tool.run({});
 
-      expect(result.is_error).toBe(true);
+      expect(result.isError).toBe(true);
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe('text');
     });

--- a/src/tools/version-tool/VersionTool.ts
+++ b/src/tools/version-tool/VersionTool.ts
@@ -20,7 +20,7 @@ export class VersionTool {
       type: 'text';
       text: string;
     }>;
-    is_error: boolean;
+    isError: boolean;
   }> {
     try {
       const versionInfo = getVersionInfo();
@@ -34,7 +34,7 @@ export class VersionTool {
 
       return {
         content: [{ type: 'text', text: versionText }],
-        is_error: false
+        isError: false
       };
     } catch (error) {
       const errorMessage =
@@ -56,7 +56,7 @@ export class VersionTool {
               : 'Internal error has occurred.'
           }
         ],
-        is_error: true
+        isError: true
       };
     }
   }


### PR DESCRIPTION
## Description

Renamed `is_error` to `isError` in accordance with the MCP spec. 
---

## Testing
````
 PASS  src/tools/matrix-tool/MatrixTool.test.ts
 PASS  src/tools/category-search-tool/CategorySearchTool.test.ts
 PASS  src/tools/poi-search-tool/PoiSearchTool.test.ts
 PASS  src/tools/reverse-geocode-tool/ReverseGeocodeTool.test.ts
 PASS  src/tools/directions-tool/DirectionsTool.test.ts
 PASS  src/tools/forward-geocode-tool/ForwardGeocodeTool.test.ts
 PASS  src/tools/directions-tool/cleanResponseData.test.ts
 PASS  src/tools/isochrone-tool/IsochroneTool.test.ts
 PASS  src/tools/static-map-image-tool/StaticMapImageTool.test.ts
 PASS  src/tools/MapboxApiBasedTool.test.ts
 PASS  src/utils/requestUtils.test.ts
 PASS  src/tools/schema-validation.test.ts
 PASS  src/tools/tool-naming-convention.test.ts
 PASS  src/tools/version-tool/VersionTool.test.ts
 PASS  src/tools/directions-tool/formatIsoDateTime.test.ts

Test Suites: 15 passed, 15 total
Tests:       238 passed, 238 total
Snapshots:   0 total
Time:        0.327 s, estimated 1 s
````

---

## Checklist

- [x] Code has been tested locally
- [x] Unit tests have been added or updated
- [x] Documentation has been updated if needed

---

## Additional Notes


[AGI-211]: https://mapbox.atlassian.net/browse/AGI-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ