### PR TITLE
Filter tools

### DIFF
--- a/TOOL_CONFIGURATION.md
+++ b/TOOL_CONFIGURATION.md
@@ -1,0 +1,82 @@
+# Tool Configuration Guide
+
+The Mapbox MCP Server supports command-line configuration to enable or disable specific tools at startup.
+
+## Command-Line Options
+
+### --enable-tools
+
+Enable only specific tools (exclusive mode). When this option is used, only the listed tools will be available.
+
+```bash
+<command> --enable-tools version_tool,directions_tool
+```
+
+### --disable-tools
+
+Disable specific tools. All other tools will remain enabled.
+
+```bash
+<command> --disable-tools static_map_image_tool,matrix_tool
+```
+
+## Available Tools
+
+The following tools are available in the Mapbox MCP Server:
+
+- `version_tool` - Get version information
+- `category_search_tool` - Search for POIs by category
+- `directions_tool` - Get directions between locations
+- `forward_geocode_tool` - Convert addresses to coordinates
+- `isochrone_tool` - Calculate reachable areas from a point
+- `matrix_tool` - Calculate travel times between multiple points
+- `poi_search_tool` - Search for points of interest
+- `reverse_geocode_tool` - Convert coordinates to addresses
+- `static_map_image_tool` - Generate static map images
+
+## Usage Examples
+
+### Node.js
+
+```bash
+node dist/index.js --enable-tools forward_geocode_tool,reverse_geocode_tool
+```
+
+### NPX
+
+```bash
+npx @mapbox/mcp-server --disable-tools static_map_image_tool
+```
+
+### Docker
+
+```bash
+docker run mapbox/mcp-server --enable-tools directions_tool,isochrone_tool,matrix_tool
+```
+
+### Claude Desktop App Configuration
+
+In your Claude Desktop configuration file:
+
+```json
+{
+  "mcpServers": {
+    "mapbox": {
+      "command": "node",
+      "args": [
+        "/path/to/index.js",
+        "--enable-tools",
+        "version_tool,directions_tool"
+      ]
+    }
+  }
+}
+```
+
+## Notes
+
+- If both `--enable-tools` and `--disable-tools` are provided, `--enable-tools` takes precedence
+- Tool names must match exactly (case-sensitive)
+- Multiple tools can be specified using comma separation
+- Invalid tool names are silently ignored
+- Arguments are passed after the main command, regardless of how the server is invoked

--- a/src/config/toolConfig.test.ts
+++ b/src/config/toolConfig.test.ts
@@ -1,0 +1,225 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  jest
+} from '@jest/globals';
+import {
+  parseToolConfigFromArgs,
+  filterTools,
+  ToolConfig
+} from './toolConfig.js';
+
+// Mock getVersionInfo to avoid import.meta.url issues in Jest
+jest.mock('../utils/versionUtils.js', () => ({
+  getVersionInfo: jest.fn(() => ({
+    name: 'Mapbox MCP server',
+    version: '1.0.0',
+    sha: 'mock-sha',
+    tag: 'mock-tag',
+    branch: 'mock-branch'
+  }))
+}));
+
+describe('Tool Configuration', () => {
+  // Save original argv
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    // Reset argv before each test
+    process.argv = [...originalArgv];
+  });
+
+  afterAll(() => {
+    // Restore original argv
+    process.argv = originalArgv;
+  });
+
+  describe('parseToolConfigFromArgs', () => {
+    it('should return empty config when no arguments provided', () => {
+      process.argv = ['node', 'index.js'];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({});
+    });
+
+    it('should parse --enable-tools with single tool', () => {
+      process.argv = ['node', 'index.js', '--enable-tools', 'version_tool'];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({
+        enabledTools: ['version_tool']
+      });
+    });
+
+    it('should parse --enable-tools with multiple tools', () => {
+      process.argv = [
+        'node',
+        'index.js',
+        '--enable-tools',
+        'version_tool,directions_tool,matrix_tool'
+      ];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({
+        enabledTools: ['version_tool', 'directions_tool', 'matrix_tool']
+      });
+    });
+
+    it('should trim whitespace from tool names', () => {
+      process.argv = [
+        'node',
+        'index.js',
+        '--enable-tools',
+        'version_tool , directions_tool , matrix_tool'
+      ];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({
+        enabledTools: ['version_tool', 'directions_tool', 'matrix_tool']
+      });
+    });
+
+    it('should parse --disable-tools with single tool', () => {
+      process.argv = [
+        'node',
+        'index.js',
+        '--disable-tools',
+        'static_map_image_tool'
+      ];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({
+        disabledTools: ['static_map_image_tool']
+      });
+    });
+
+    it('should parse --disable-tools with multiple tools', () => {
+      process.argv = [
+        'node',
+        'index.js',
+        '--disable-tools',
+        'static_map_image_tool,matrix_tool'
+      ];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({
+        disabledTools: ['static_map_image_tool', 'matrix_tool']
+      });
+    });
+
+    it('should parse both --enable-tools and --disable-tools', () => {
+      process.argv = [
+        'node',
+        'index.js',
+        '--enable-tools',
+        'version_tool',
+        '--disable-tools',
+        'matrix_tool'
+      ];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({
+        enabledTools: ['version_tool'],
+        disabledTools: ['matrix_tool']
+      });
+    });
+
+    it('should handle missing value for --enable-tools', () => {
+      process.argv = ['node', 'index.js', '--enable-tools'];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({});
+    });
+
+    it('should handle missing value for --disable-tools', () => {
+      process.argv = ['node', 'index.js', '--disable-tools'];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({});
+    });
+
+    it('should ignore unknown arguments', () => {
+      process.argv = [
+        'node',
+        'index.js',
+        '--unknown-arg',
+        'value',
+        '--enable-tools',
+        'version_tool'
+      ];
+      const config = parseToolConfigFromArgs();
+      expect(config).toEqual({
+        enabledTools: ['version_tool']
+      });
+    });
+  });
+
+  describe('filterTools', () => {
+    // Mock tools for testing
+    const mockTools = [
+      { name: 'version_tool', description: 'Version tool' },
+      { name: 'directions_tool', description: 'Directions tool' },
+      { name: 'matrix_tool', description: 'Matrix tool' },
+      { name: 'static_map_image_tool', description: 'Static map tool' }
+    ] as any;
+
+    it('should return all tools when no config provided', () => {
+      const config: ToolConfig = {};
+      const filtered = filterTools(mockTools, config);
+      expect(filtered).toEqual(mockTools);
+    });
+
+    it('should filter tools based on enabledTools', () => {
+      const config: ToolConfig = {
+        enabledTools: ['version_tool', 'directions_tool']
+      };
+      const filtered = filterTools(mockTools, config);
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((t) => t.name)).toEqual([
+        'version_tool',
+        'directions_tool'
+      ]);
+    });
+
+    it('should filter tools based on disabledTools', () => {
+      const config: ToolConfig = {
+        disabledTools: ['matrix_tool', 'static_map_image_tool']
+      };
+      const filtered = filterTools(mockTools, config);
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((t) => t.name)).toEqual([
+        'version_tool',
+        'directions_tool'
+      ]);
+    });
+
+    it('should prioritize enabledTools over disabledTools', () => {
+      const config: ToolConfig = {
+        enabledTools: ['version_tool'],
+        disabledTools: ['version_tool', 'directions_tool']
+      };
+      const filtered = filterTools(mockTools, config);
+      expect(filtered).toHaveLength(1);
+      expect(filtered.map((t) => t.name)).toEqual(['version_tool']);
+    });
+
+    it('should handle non-existent tool names gracefully', () => {
+      const config: ToolConfig = {
+        enabledTools: ['version_tool', 'non_existent_tool']
+      };
+      const filtered = filterTools(mockTools, config);
+      expect(filtered).toHaveLength(1);
+      expect(filtered.map((t) => t.name)).toEqual(['version_tool']);
+    });
+
+    it('should return empty array when enabledTools is empty', () => {
+      const config: ToolConfig = {
+        enabledTools: []
+      };
+      const filtered = filterTools(mockTools, config);
+      expect(filtered).toHaveLength(0);
+    });
+
+    it('should return all tools when disabledTools is empty', () => {
+      const config: ToolConfig = {
+        disabledTools: []
+      };
+      const filtered = filterTools(mockTools, config);
+      expect(filtered).toEqual(mockTools);
+    });
+  });
+});

--- a/src/config/toolConfig.ts
+++ b/src/config/toolConfig.ts
@@ -1,0 +1,55 @@
+import { ToolInstance } from '../tools/toolRegistry.js';
+
+export interface ToolConfig {
+  enabledTools?: string[];
+  disabledTools?: string[];
+}
+
+export function parseToolConfigFromArgs(): ToolConfig {
+  const args = process.argv.slice(2);
+  const config: ToolConfig = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '--enable-tools') {
+      const value = args[++i];
+      if (value) {
+        config.enabledTools = value.split(',').map((t) => t.trim());
+      }
+    } else if (arg === '--disable-tools') {
+      const value = args[++i];
+      if (value) {
+        config.disabledTools = value.split(',').map((t) => t.trim());
+      }
+    }
+  }
+
+  return config;
+}
+
+export function filterTools(
+  tools: readonly ToolInstance[],
+  config: ToolConfig
+): ToolInstance[] {
+  let filteredTools = [...tools];
+
+  // If enabledTools is specified, only those tools should be enabled
+  // This takes precedence over disabledTools
+  if (config.enabledTools !== undefined) {
+    filteredTools = filteredTools.filter((tool) =>
+      config.enabledTools!.includes(tool.name)
+    );
+    // Return early since enabledTools takes precedence
+    return filteredTools;
+  }
+
+  // Apply disabledTools filter only if enabledTools is not specified
+  if (config.disabledTools && config.disabledTools.length > 0) {
+    filteredTools = filteredTools.filter(
+      (tool) => !config.disabledTools!.includes(tool.name)
+    );
+  }
+
+  return filteredTools;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,19 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { parseToolConfigFromArgs, filterTools } from './config/toolConfig.js';
 import { getAllTools } from './tools/toolRegistry.js';
 import { patchGlobalFetch } from './utils/requestUtils.js';
 import { getVersionInfo } from './utils/versionUtils.js';
 
 let serverVersionInfo = getVersionInfo();
 patchGlobalFetch(serverVersionInfo);
+
+// Parse configuration from command-line arguments
+const config = parseToolConfigFromArgs();
+
+// Get and filter tools based on configuration
+const allTools = getAllTools();
+const enabledTools = filterTools(allTools, config);
 
 // Create an MCP server
 const server = new McpServer(
@@ -20,8 +28,8 @@ const server = new McpServer(
   }
 );
 
-// Register all tools from the registry
-getAllTools().forEach((tool) => {
+// Register enabled tools to the server
+enabledTools.forEach((tool) => {
   tool.installTo(server);
 });
 


### PR DESCRIPTION
## PR Description

  ### Add Tool Configuration Support via Command-Line Arguments

  This PR introduces the ability to selectively enable or disable tools at server startup through command-line arguments, providing users with fine-grained control over which Mapbox tools are available in their MCP server instance.

  ### Features Added

  - **`--enable-tools`**: Specify exactly which tools should be enabled (exclusive mode)
  - **`--disable-tools`**: Specify which tools to exclude from the default set
  - **Precedence handling**: When both flags are provided, `--enable-tools` takes precedence
  - **Flexible syntax**: Multiple tools can be specified using comma separation with automatic whitespace trimming

  ### Implementation Details

  - Added new `toolConfig` module with parsing and filtering logic
  - Integrated configuration parsing into the main server initialization
  - Comprehensive test coverage with 17 test cases covering all scenarios
  - Full documentation in `TOOL_CONFIGURATION.md`

  ### Usage Examples

  ```bash
  # Enable only geocoding tools
  node dist/index.js --enable-tools forward_geocode_tool,reverse_geocode_tool

  # Disable static map generation
  npx @mapbox/mcp-server --disable-tools static_map_image_tool

  # Claude Desktop configuration
  {
    "mcpServers": {
      "mapbox": {
        "command": "node",
        "args": ["/path/to/index.js", "--enable-tools",
  "version_tool,directions_tool"]
      }
    }
  }

  Testing

  - All new tests pass (17/17)
  - No linting errors introduced
  - Backward compatible - works without any configuration flags

  Benefits

  - Reduces memory footprint when only specific tools are needed
  - Improves security by limiting exposed functionality
  - Enables specialized server configurations for different use cases
  - Maintains full backward compatibility

  ---
  🤖 Generated with https://claude.ai/code

  Co-Authored-By: Claude noreply@anthropic.com
  ```