### PR TITLE
Two build / run related bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN mkdir -p dist && echo '{"sha":"unknown","tag":"unknown","branch":"docker","v
 
 # Build the application, overriding the git commands to avoid errors
 RUN npx tshy
+RUN cp package.json dist/package.json
 
 # Command to run the server
 CMD ["node", "dist/esm/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN mkdir -p dist && echo '{"sha":"unknown","tag":"unknown","branch":"docker","v
 
 # Build the application, overriding the git commands to avoid errors
 RUN npx tshy
-RUN cp package.json dist/package.json
 
 # Command to run the server
 CMD ["node", "dist/esm/index.js"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ const server = new McpServer(
   },
   {
     capabilities: {
-      tools: {}
+      tools: {},
+      logging: {}
     }
   }
 );


### PR DESCRIPTION
Logging needs to be defined in index.ts

(removed the other change to the dockerfile as it is not necessary for preferred way of accessing/running mcp)

## Description

When logging is not enabled in index.ts, it leads to a logging error which then closes the connection to the server.  

---

## Checklist

- [x] Code has been tested locally
- [ ] Unit tests have been added or updated
- [ ] Documentation has been updated if needed

