### PR TITLE
[bug] Fix version utils package.json path

### DIFF
--- a/src/utils/versionUtils-cjs.cts
+++ b/src/utils/versionUtils-cjs.cts
@@ -15,7 +15,7 @@ export function getVersionInfo(): VersionInfo {
     const dirname = __dirname;
 
     // Try to read from version.json first (for build artifacts)
-    const versionJsonPath = path.resolve(dirname, '..', 'version.json');
+    const versionJsonPath = path.resolve(dirname, '..', '..', 'version.json');
     try {
       const versionData = readFileSync(versionJsonPath, 'utf-8');
       const info = JSON.parse(versionData) as VersionInfo;
@@ -23,7 +23,13 @@ export function getVersionInfo(): VersionInfo {
       return info;
     } catch {
       // Fall back to package.json
-      const packageJsonPath = path.resolve(dirname, '..', '..', 'package.json');
+      const packageJsonPath = path.resolve(
+        dirname,
+        '..',
+        '..',
+        '..',
+        'package.json'
+      );
       const packageData = readFileSync(packageJsonPath, 'utf-8');
       const packageInfo = JSON.parse(packageData);
 

--- a/src/utils/versionUtils.ts
+++ b/src/utils/versionUtils.ts
@@ -18,7 +18,7 @@ export function getVersionInfo(): VersionInfo {
     const dirname = path.dirname(fileURLToPath(import.meta.url));
 
     // Try to read from version.json first (for build artifacts)
-    const versionJsonPath = path.resolve(dirname, '..', 'version.json');
+    const versionJsonPath = path.resolve(dirname, '..', '..', 'version.json');
     try {
       const versionData = readFileSync(versionJsonPath, 'utf-8');
       const info = JSON.parse(versionData) as VersionInfo;
@@ -26,7 +26,13 @@ export function getVersionInfo(): VersionInfo {
       return info;
     } catch {
       // Fall back to package.json
-      const packageJsonPath = path.resolve(dirname, '..', '..', 'package.json');
+      const packageJsonPath = path.resolve(
+        dirname,
+        '..',
+        '..',
+        '..',
+        'package.json'
+      );
       const packageData = readFileSync(packageJsonPath, 'utf-8');
       const packageInfo = JSON.parse(packageData);
 


### PR DESCRIPTION
## Description

Updates the version utils path to pick up the package.json from the proper directory.

- Fixes: #40

---

## Testing

All tests pass still, no changes

---

## Checklist

- [x] Code has been tested locally
- [ ] Unit tests have been added or updated
- [ ] Documentation has been updated if needed

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->
