### PR TITLE
Add Tools Annotation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mcp-server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mcp-server",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@mapbox/mcp-server",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mcp-server",
-      "version": "0.4.0",
-      "license": "BSD-3-Clause",
+      "version": "0.5.1",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",
         "dotenv": "^17.2.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prepare": "husky && node .husky/setup-hooks.js",
     "test": "vitest",
     "build": "npm run prepare && tshy && npm run generate-version && node scripts/add-shebang.cjs",
-    "generate-version": "node scripts/build-helpers.cjs generate-version"
+    "generate-version": "node scripts/build-helpers.cjs generate-version",
+    "dev:inspect": "npm run build && npx @modelcontextprotocol/inspector -e MAPBOX_ACCESS_TOKEN=\"$MAPBOX_ACCESS_TOKEN\" node dist/esm/index.js"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mcp-server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Mapbox MCP server.",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,7 @@ const server = new McpServer(
   },
   {
     capabilities: {
-      tools: {},
-      logging: {}
+      tools: {}
     }
   }
 );

--- a/src/tools/MapboxApiBasedTool.ts
+++ b/src/tools/MapboxApiBasedTool.ts
@@ -4,6 +4,7 @@ import type {
 } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { ZodTypeAny } from 'zod';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 
 export const OutputSchema = z.object({
@@ -26,6 +27,7 @@ export const OutputSchema = z.object({
 export abstract class MapboxApiBasedTool<InputSchema extends ZodTypeAny> {
   abstract readonly name: string;
   abstract readonly description: string;
+  abstract readonly annotations: ToolAnnotations;
 
   readonly inputSchema: InputSchema;
   protected server: McpServer | null = null;
@@ -136,10 +138,14 @@ export abstract class MapboxApiBasedTool<InputSchema extends ZodTypeAny> {
    */
   installTo(server: McpServer): RegisteredTool {
     this.server = server;
-    return server.tool(
+    return server.registerTool(
       this.name,
-      this.description,
-      (this.inputSchema as unknown as z.ZodObject<any>).shape,
+      {
+        title: this.annotations.title,
+        description: this.description,
+        inputSchema: (this.inputSchema as unknown as z.ZodObject<any>).shape,
+        annotations: this.annotations
+      },
       (args, extra) => this.run(args, extra)
     );
   }

--- a/src/tools/category-list-tool/CategoryListTool.ts
+++ b/src/tools/category-list-tool/CategoryListTool.ts
@@ -47,6 +47,13 @@ export class CategoryListTool extends MapboxApiBasedTool<
   name = 'category_list_tool';
   description =
     'Tool for retrieving the list of supported categories from Mapbox Search API. Use this when another function requires a list of categories. Returns all available category IDs by default. Only use pagination (limit/offset) if token usage optimization is required. If using pagination, make multiple calls to retrieve ALL categories before proceeding with other tasks to ensure complete data.';
+  annotations = {
+    title: 'Category List Tool',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true
+  };
 
   constructor(private fetchImpl: typeof fetch = fetchClient) {
     super({ inputSchema: CategoryListInputSchema });

--- a/src/tools/category-search-tool/CategorySearchTool.ts
+++ b/src/tools/category-search-tool/CategorySearchTool.ts
@@ -104,6 +104,13 @@ export class CategorySearchTool extends MapboxApiBasedTool<
   name = 'category_search_tool';
   description =
     "Return all places that match a category (industry, amenity, or NAICS‑style code). Use when the user asks for a type of place, plural or generic terms like 'museums', 'coffee shops', 'electric‑vehicle chargers', or when the query includes is‑a phrases such as 'any', 'all', 'nearby'. Do not use when a unique name or brand is provided. Supports both JSON and text output formats.";
+  annotations = {
+    title: 'Category Search Tool',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: CategorySearchInputSchema });

--- a/src/tools/directions-tool/DirectionsTool.ts
+++ b/src/tools/directions-tool/DirectionsTool.ts
@@ -301,6 +301,13 @@ export class DirectionsTool extends MapboxApiBasedTool<
   name = 'directions_tool';
   description =
     'Fetches directions from Mapbox API based on provided coordinates and direction method.';
+  annotations = {
+    title: 'Directions Tool',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: DirectionsInputSchema });

--- a/src/tools/isochrone-tool/IsochroneTool.ts
+++ b/src/tools/isochrone-tool/IsochroneTool.ts
@@ -93,6 +93,13 @@ export class IsochroneTool extends MapboxApiBasedTool<
     - Show a user how far they can travel in X minutes from their current location
     - Determine whether a destination is within a certain travel time threshold
     - Compare travel ranges for different modes of transportation'`;
+  annotations = {
+    title: 'Isochrone Tool',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true
+  };
 
   private fetch: typeof globalThis.fetch;
 

--- a/src/tools/matrix-tool/MatrixTool.ts
+++ b/src/tools/matrix-tool/MatrixTool.ts
@@ -86,6 +86,13 @@ export class MatrixTool extends MapboxApiBasedTool<typeof MatrixInputSchema> {
   name = 'matrix_tool';
   description =
     'Calculates travel times and distances between multiple points using Mapbox Matrix API.';
+  annotations = {
+    title: 'Matrix Tool',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true
+  };
 
   private fetch: typeof globalThis.fetch;
 

--- a/src/tools/reverse-geocode-tool/ReverseGeocodeTool.ts
+++ b/src/tools/reverse-geocode-tool/ReverseGeocodeTool.ts
@@ -72,6 +72,13 @@ export class ReverseGeocodeTool extends MapboxApiBasedTool<
   name = 'reverse_geocode_tool';
   description =
     'Find addresses, cities, towns, neighborhoods, postcodes, districts, regions, and countries around a specified geographic coordinate pair. Converts geographic coordinates (longitude, latitude) into human-readable addresses or place names. Use limit=1 for best results. This tool cannot reverse geocode businesses, landmarks, historic sites, and other points of interest that are not of the types mentioned. Supports both JSON and text output formats.';
+  annotations = {
+    title: 'Reverse Geocode Tool',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: ReverseGeocodeInputSchema });

--- a/src/tools/search-and-geocode-tool/SearchAndGeocodeTool.ts
+++ b/src/tools/search-and-geocode-tool/SearchAndGeocodeTool.ts
@@ -101,6 +101,13 @@ export class SearchAndGeocodeTool extends MapboxApiBasedTool<
   name = 'search_and_geocode_tool';
   description =
     "Search for POIs, brands, chains, geocode cities, towns, addresses. Do not use for generic place types such as 'museums', 'coffee shops', 'tacos', etc, because category_search_tool is better for that. Setting a proximity point is strongly encouraged for more local results.";
+  annotations = {
+    title: 'Search and Geocode Tool',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true
+  };
 
   constructor(private fetchImpl: typeof fetch = fetchClient) {
     super({ inputSchema: SearchAndGeocodeInputSchema });

--- a/src/tools/static-map-image-tool/StaticMapImageTool.ts
+++ b/src/tools/static-map-image-tool/StaticMapImageTool.ts
@@ -362,6 +362,13 @@ export class StaticMapImageTool extends MapboxApiBasedTool<
   name = 'static_map_image_tool';
   description =
     'Generates a static map image from Mapbox Static Images API. Supports center coordinates, zoom level (0-22), image size (up to 1280x1280), various Mapbox styles, and overlays (markers, paths, GeoJSON). Returns PNG for vector styles, JPEG for raster-only styles.';
+  annotations = {
+    title: 'Static Map Image Tool',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true
+  };
 
   constructor(private fetch: typeof globalThis.fetch = fetchClient) {
     super({ inputSchema: StaticMapImageInputSchema });

--- a/src/tools/version-tool/VersionTool.ts
+++ b/src/tools/version-tool/VersionTool.ts
@@ -2,6 +2,7 @@ import type {
   McpServer,
   RegisteredTool
 } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { getVersionInfo } from '../../utils/versionUtils.js';
 
@@ -12,6 +13,13 @@ export class VersionTool {
   readonly description =
     'Get the current version information of the MCP server';
   readonly inputSchema = InputSchema;
+  readonly annotations: ToolAnnotations = {
+    title: 'Version Information Tool',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false
+  };
 
   private server: McpServer | null = null;
 
@@ -60,10 +68,14 @@ export class VersionTool {
 
   installTo(server: McpServer): RegisteredTool {
     this.server = server;
-    return server.tool(
+    return server.registerTool(
       this.name,
-      this.description,
-      this.inputSchema.shape,
+      {
+        title: this.annotations.title,
+        description: this.description,
+        inputSchema: this.inputSchema.shape,
+        annotations: this.annotations
+      },
       this.run.bind(this)
     );
   }

--- a/test/tools/annotations.test.ts
+++ b/test/tools/annotations.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { getAllTools } from '../../src/tools/toolRegistry.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+describe('Tool Annotations', () => {
+  it('should have annotations for all tools', () => {
+    const tools = getAllTools();
+
+    tools.forEach((tool) => {
+      expect(tool.annotations).toBeDefined();
+      expect(typeof tool.annotations.title).toBe('string');
+      expect(tool.annotations.title).toBeTruthy();
+      expect(typeof tool.annotations.readOnlyHint).toBe('boolean');
+      expect(typeof tool.annotations.destructiveHint).toBe('boolean');
+      expect(typeof tool.annotations.idempotentHint).toBe('boolean');
+      expect(typeof tool.annotations.openWorldHint).toBe('boolean');
+    });
+  });
+
+  it('should properly install tools with annotations to server', () => {
+    const server = new McpServer(
+      { name: 'test-server', version: '1.0.0' },
+      { capabilities: { tools: {} } }
+    );
+
+    const tools = getAllTools();
+    const registeredTools = tools.map((tool) => tool.installTo(server as any));
+
+    // All tools should be registered successfully
+    expect(registeredTools).toHaveLength(tools.length);
+    registeredTools.forEach((registeredTool) => {
+      expect(registeredTool).toBeDefined();
+    });
+  });
+
+  it('should have appropriate read-only hints for search tools', () => {
+    const tools = getAllTools();
+
+    // Search tools should be read-only
+    const searchTools = tools.filter(
+      (tool) =>
+        tool.name.includes('search') ||
+        tool.name.includes('geocode') ||
+        tool.name.includes('category') ||
+        tool.name.includes('version') ||
+        tool.name.includes('matrix') ||
+        tool.name.includes('directions') ||
+        tool.name.includes('isochrone') ||
+        tool.name.includes('static_map')
+    );
+
+    searchTools.forEach((tool) => {
+      expect(tool.annotations.readOnlyHint).toBe(true);
+      expect(tool.annotations.destructiveHint).toBe(false);
+    });
+  });
+
+  it('should have open world hints for external API tools', () => {
+    const tools = getAllTools();
+
+    // Most Mapbox API tools interact with external services (open world)
+    const apiTools = tools.filter((tool) => tool.name !== 'version_tool');
+
+    apiTools.forEach((tool) => {
+      expect(tool.annotations.openWorldHint).toBe(true);
+    });
+  });
+
+  it('should have closed world hint for version tool', () => {
+    const tools = getAllTools();
+    const versionTool = tools.find((tool) => tool.name === 'version_tool');
+
+    expect(versionTool).toBeDefined();
+    expect(versionTool!.annotations.openWorldHint).toBe(false);
+  });
+});


### PR DESCRIPTION
This pull request introduces a standardized `annotations` property to all tools in the MCP server, enhancing metadata consistency and enabling richer introspection of tool capabilities. It also updates the tool registration process to utilize these annotations and adds comprehensive tests to ensure annotation correctness. Additionally, a new development script is added for tool inspection.

**Tool metadata standardization and registration:**

* All tool classes (e.g., `CategoryListTool`, `CategorySearchTool`, `DirectionsTool`, `IsochroneTool`, `MatrixTool`, `ReverseGeocodeTool`, `SearchAndGeocodeTool`, `StaticMapImageTool`, `VersionTool`) now include a required `annotations` property, specifying metadata such as `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`. [[1]](diffhunk://#diff-f3183e35a8410425b5adaefad4c53d7bcf1f70afc53df9a186bbdf7b3209d22eR30) [[2]](diffhunk://#diff-43a9a60a2f533aa40e45be054d9588146d308a6b50d8ee5cae7f62e6a9a615c0R50-R56) [[3]](diffhunk://#diff-afdcf48eab74ab82aa0357281bb9159eba1b87403ac4661bacf01ed8fac19439R107-R113) [[4]](diffhunk://#diff-050607afb9ec19a433ab9389d708979b97e899c277c5da3ce17131d874563854R304-R310) [[5]](diffhunk://#diff-a6d4717dcdde921e6cefa8fc994e7efa015a088f7e9d79ecd329cce2a273fd28R96-R102) [[6]](diffhunk://#diff-0b2dca4cf955cc74cf2ba6ef71335f8774372d51ac3f102af5a591de125d6f6eR89-R95) [[7]](diffhunk://#diff-d1d54b7f3de05340147457089698f0f775b341e1b6f3d0cd16428aeb19495fd8R75-R81) [[8]](diffhunk://#diff-b3be37380de8ca71abc8324548ffa063eb7f15792aa59d950b717155a48b3c7bR104-R110) [[9]](diffhunk://#diff-b26132101f2199c07c1cd075b94a1e079c41fe3d243d4d17ad267a9289d79238R16-R22)
* The `installTo` method in all tool classes has been updated to use `server.registerTool` instead of `server.tool`, passing the new annotations and structured tool metadata during registration. [[1]](diffhunk://#diff-f3183e35a8410425b5adaefad4c53d7bcf1f70afc53df9a186bbdf7b3209d22eL139-R148) [[2]](diffhunk://#diff-b26132101f2199c07c1cd075b94a1e079c41fe3d243d4d17ad267a9289d79238L63-R78)

**Testing and validation:**

* Added a new test file `annotations.test.ts` to verify that all tools include properly structured annotations, are registered correctly, and that their metadata hints (e.g., `readOnlyHint`, `openWorldHint`) are appropriate for their function.

**Developer tooling:**

* Added a `dev:inspect` script to `package.json` for building the project and running the Model Context Protocol inspector with the correct environment variables, improving developer experience for tool inspection.

**Versioning:**

* Bumped the package version from `0.5.1` to `0.5.2` to reflect these enhancements.

**Minor refactoring:**

* Removed the unused `logging` capability from the MCP server instantiation in `src/index.ts`.