### PR TITLE
Ensure manifest.json version always matches the package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Husky
-
-.husky/pre-commit
-
 # Logs
 
 logs

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+npm run sync-manifest
+git add manifest.json
+npx lint-staged

--- a/.husky/setup-hooks.js
+++ b/.husky/setup-hooks.js
@@ -1,7 +1,6 @@
-/*global console*/
-import { writeFileSync, mkdirSync, chmodSync, constants } from 'fs';
-import { execSync } from 'child_process';
-import { platform } from 'os';
+import { writeFileSync, mkdirSync, chmodSync, constants } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { platform } from 'node:os';
 
 mkdirSync('.husky', { recursive: true });
 
@@ -10,6 +9,8 @@ execSync('git config core.hooksPath .husky');
 writeFileSync(
   '.husky/pre-commit',
   `#!/usr/bin/env sh
+npm run sync-manifest
+git add manifest.json
 npx lint-staged`
 );
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "dxt_version": "0.1",
   "name": "@mapbox/mcp-server",
   "display_name": "Mapbox MCP Server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Mapbox MCP server.",
   "author": {
     "name": "Mapbox, Inc."
@@ -16,7 +16,7 @@
         "${__dirname}/dist/esm/index.js"
       ],
       "env": {
-        "MAPBOX_ACCESS_TOKEN" : "${user_config.MAPBOX_ACCESS_TOKEN}"
+        "MAPBOX_ACCESS_TOKEN": "${user_config.MAPBOX_ACCESS_TOKEN}"
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "dxt_version": "0.1",
   "name": "@mapbox/mcp-server",
   "display_name": "Mapbox MCP Server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Mapbox MCP server.",
   "author": {
     "name": "Mapbox, Inc."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mcp-server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mcp-server",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "vitest",
     "build": "npm run prepare && tshy && npm run generate-version && node scripts/add-shebang.cjs",
     "generate-version": "node scripts/build-helpers.cjs generate-version",
+    "sync-manifest": "node scripts/sync-manifest-version.cjs",
     "dev:inspect": "npm run build && npx @modelcontextprotocol/inspector -e MAPBOX_ACCESS_TOKEN=\"$MAPBOX_ACCESS_TOKEN\" node dist/esm/index.js"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mcp-server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Mapbox MCP server.",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/scripts/sync-manifest-version.cjs
+++ b/scripts/sync-manifest-version.cjs
@@ -1,0 +1,36 @@
+// Sync manifest.json version with package.json
+const fs = require('node:fs');
+const path = require('node:path');
+
+function syncManifestVersion() {
+  const packageJsonPath = path.join(process.cwd(), 'package.json');
+  const manifestJsonPath = path.join(process.cwd(), 'manifest.json');
+
+  // Read package.json
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  const packageVersion = packageJson.version;
+
+  // Read manifest.json
+  const manifestJson = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf-8'));
+  const manifestVersion = manifestJson.version;
+
+  // Check if versions are already in sync
+  if (manifestVersion === packageVersion) {
+    console.log(`✓ Versions already in sync: ${packageVersion}`);
+    return;
+  }
+
+  // Update manifest.json version
+  manifestJson.version = packageVersion;
+  fs.writeFileSync(
+    manifestJsonPath,
+    JSON.stringify(manifestJson, null, 2) + '\n',
+    'utf-8'
+  );
+
+  console.log(
+    `✓ Updated manifest.json version: ${manifestVersion} → ${packageVersion}`
+  );
+}
+
+syncManifestVersion();

--- a/test/version-consistency.test.ts
+++ b/test/version-consistency.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('Version Consistency', () => {
+  it('manifest.json version should match package.json version', () => {
+    const packageJsonPath = join(process.cwd(), 'package.json');
+    const manifestJsonPath = join(process.cwd(), 'manifest.json');
+
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    const manifestJson = JSON.parse(readFileSync(manifestJsonPath, 'utf-8'));
+
+    expect(manifestJson.version).toBe(packageJson.version);
+  });
+});


### PR DESCRIPTION
This pull request introduces automation to ensure that the `manifest.json` version always matches the `package.json` version, reducing the risk of version mismatches and streamlining the release process. It adds a script to sync versions, integrates this check into the pre-commit workflow, and adds a test to enforce consistency. Additionally, the project version is updated to `0.5.3`.

**Version synchronization automation:**

* Added a new script `scripts/sync-manifest-version.cjs` that automatically updates the `manifest.json` version to match the `package.json` version.
* Registered a new npm script `sync-manifest` in `package.json`, and updated the pre-commit hook to run this script and stage `manifest.json` before linting. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R20) [[2]](diffhunk://#diff-40ca490b03e43c532e3594ecaf271a4889180a3c4d1bb8a5445ccdfc27a3fbb5R12-R13)

**Testing and enforcement:**

* Added a test (`test/version-consistency.test.ts`) to verify that the versions in `manifest.json` and `package.json` are always consistent.

**Dependency and version updates:**

* Updated the project version to `0.5.3` in both `package.json` and `manifest.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L5-R5)

**Codebase modernization:**

* Updated Node.js import styles in `.husky/setup-hooks.js` for consistency and future compatibility.