### PR TITLE
fix: prevent access token leak in MCP-UI iframe URL (CWE-200)

### DIFF
--- a/src/tools/static-map-image-tool/StaticMapImageTool.ts
+++ b/src/tools/static-map-image-tool/StaticMapImageTool.ts
@@ -169,7 +169,7 @@ export class StaticMapImageTool extends MapboxApiBasedTool<
         uri: `ui://mapbox/static-map/${input.style}/${lng},${lat},${input.zoom}`,
         content: {
           type: 'externalUrl',
-          iframeUrl: url
+          iframeUrl: publicUrl
         },
         encoding: 'text',
         uiMetadata: {

--- a/test/tools/static-map-image-tool/StaticMapImageTool.token-leak.test.ts
+++ b/test/tools/static-map-image-tool/StaticMapImageTool.token-leak.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Mapbox, Inc.
+// Licensed under the MIT License.
+
+// PoC test: Verify that the access token is NOT leaked in the UIResource
+// sent to the client when MCP-UI is enabled.
+
+process.env.MAPBOX_ACCESS_TOKEN =
+  'sk.eyJ1IjoiYXR0YWNrZXIiLCJhIjoic2VjcmV0In0.secret_key';
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupHttpRequest } from '../../utils/httpPipelineUtils.js';
+import { StaticMapImageTool } from '../../../src/tools/static-map-image-tool/StaticMapImageTool.js';
+
+describe('StaticMapImageTool - token leak prevention', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('UIResource must not contain the access token', async () => {
+    // Ensure MCP-UI is enabled so the UIResource is generated
+    const originalEnv = process.env.ENABLE_MCP_UI;
+    process.env.ENABLE_MCP_UI = 'true';
+
+    try {
+      const { httpRequest } = setupHttpRequest();
+
+      const result = await new StaticMapImageTool({ httpRequest }).run({
+        center: { longitude: -74.006, latitude: 40.7128 },
+        zoom: 12,
+        size: { width: 600, height: 400 },
+        style: 'mapbox/streets-v12'
+      });
+
+      expect(result.isError).toBe(false);
+
+      // Find the UIResource in the response
+      const resourceContent = result.content.find((c) => c.type === 'resource');
+      expect(resourceContent).toBeDefined();
+
+      // Serialize the entire resource to check for token leakage
+      const resourceStr = JSON.stringify(resourceContent);
+
+      // The access token must NOT appear anywhere in the UIResource
+      expect(resourceStr).not.toContain('access_token=');
+      expect(resourceStr).not.toContain(
+        'sk.eyJ1IjoiYXR0YWNrZXIiLCJhIjoic2VjcmV0In0.secret_key'
+      );
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env.ENABLE_MCP_UI = originalEnv;
+      } else {
+        delete process.env.ENABLE_MCP_UI;
+      }
+    }
+  });
+
+  it('UIResource iframeUrl should use publicUrl without credentials', async () => {
+    const originalEnv = process.env.ENABLE_MCP_UI;
+    process.env.ENABLE_MCP_UI = 'true';
+
+    try {
+      const { httpRequest } = setupHttpRequest();
+
+      const result = await new StaticMapImageTool({ httpRequest }).run({
+        center: { longitude: -122.4194, latitude: 37.7749 },
+        zoom: 13,
+        size: { width: 800, height: 600 },
+        style: 'mapbox/satellite-streets-v12'
+      });
+
+      expect(result.isError).toBe(false);
+
+      const resourceContent = result.content.find((c) => c.type === 'resource');
+      expect(resourceContent).toBeDefined();
+
+      if (resourceContent?.type === 'resource') {
+        const resource = resourceContent.resource;
+        // The resource text (which is the iframeUrl for externalUrl type)
+        // should contain the map URL but NOT the access token
+        if ('text' in resource && typeof resource.text === 'string') {
+          expect(resource.text).toContain('api.mapbox.com/styles/v1/');
+          expect(resource.text).not.toContain('access_token=');
+        }
+      }
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env.ENABLE_MCP_UI = originalEnv;
+      } else {
+        delete process.env.ENABLE_MCP_UI;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Security Fix: Prevent Mapbox Access Token Leak in MCP-UI Resource (CWE-200)

### Vulnerability Summary

| Field | Value |
|-------|-------|
| **CWE** | [CWE-200](https://cwe.mitre.org/data/definitions/200.html): Exposure of Sensitive Information to an Unauthorized Actor |
| **Severity** | Medium |
| **File** | `src/tools/static-map-image-tool/StaticMapImageTool.ts` |
| **Affected versions** | Current `main` (initial commit `4b44f5e`) |

#### Data Flow

1. `StaticMapImageTool.execute()` receives `accessToken` from `MapboxApiBasedTool.run()` (sourced from `extra.authInfo.token` or `process.env.MAPBOX_ACCESS_TOKEN`).
2. A signed URL is constructed: `url = publicUrl + ?access_token=${accessToken}` (line ~127).
3. A `publicUrl` (without credentials) is correctly used in `content[0].text` (line ~141).
4. **Bug**: When MCP-UI is enabled (default), `createUIResource()` is called with `iframeUrl: url` — the **credential-bearing** URL — at line 172. This embeds the full access token in the tool result returned over the MCP protocol to clients.

The access token (including potentially secret `sk.*` tokens) is transmitted to **any** MCP client that invokes the `static_map_image` tool with MCP-UI enabled.

### Fix Description

**One-line change** — `iframeUrl: url` → `iframeUrl: publicUrl`:

```diff
- iframeUrl: url
+ iframeUrl: publicUrl
```

**Rationale**: The `publicUrl` variable is already constructed earlier in the same function and is deliberately used in `content[0].text` for exactly this reason — the code comment on line 139-140 states: *"Use public URL (without credentials) to avoid leaking the access token"*. The `iframeUrl` assignment was simply missed when this pattern was established. This fix aligns the MCP-UI code path with the existing, intentional design.

### Test Results

Two new security regression tests were added in `test/tools/static-map-image-tool/StaticMapImageTool.token-leak.test.ts`:

| Test | Purpose | Status |
|------|---------|--------|
| `UIResource must not contain the access token` | Serializes the entire UIResource to JSON and checks that neither `access_token=` nor the literal token value appear anywhere | ✅ Pass |
| `UIResource iframeUrl should use publicUrl without credentials` | Verifies the resource text contains the Mapbox API URL but not the `access_token` query parameter | ✅ Pass |

Both tests use a secret-format token (`sk.eyJ1...`) as `MAPBOX_ACCESS_TOKEN` to exercise the worst-case scenario.

### Disprove Analysis Results

This fix passed a structured 4-stage review that included an explicit attempt to disprove the finding:

#### Authentication Check
No additional auth decorators exist on `StaticMapImageTool` itself. Authentication is handled in the parent class, and the resulting `accessToken` is passed directly to `execute()`.

#### Network Exposure Check
The MCP server uses **stdio** transport by default and also supports a hosted, internet-facing endpoint at `https://mcp.mapbox.com/mcp` (streamable HTTP). No VPN/localhost-only restrictions were found.

#### Caller Trace (Confirmed)
`createUIResource` is called with `iframeUrl: url` (the credential-bearing URL). The UIResource is pushed into the `content[]` array returned over the MCP protocol. **The access token is directly reachable in the tool result sent to the MCP client.**

#### Input Validation Check
No sanitization, escaping, or token redaction exists before `iframeUrl` is set. The token is passed through raw.

#### Fix Adequacy Check (Not Cosmetic)
- Only `StaticMapImageTool` uses `createUIResource` with `externalUrl` — no other tool returns a UIResource containing the access token.
- Other tools use `access_token` only for server-side API calls and never expose it in tool results.
- The fix is consistent with the deliberate design choice already present in the same function (`content[0].text` already uses `publicUrl`).

#### Prior Reports
No prior security issues found via `gh issue list --search "security OR CVE OR vulnerability"`. No `SECURITY.md` file exists in the repository.

#### Similar Vulnerabilities
No other instances of `createUIResource` with `externalUrl` exist in the codebase. This is the only occurrence.

### Attack Vectors

With the **unfixed** code, an attacker with access to MCP tool results (e.g., malicious extension, log files, LLM conversation history, or network interception on HTTP transport) could extract the Mapbox access token from the UIResource:

- **Referrer leakage**: If the MCP-UI client loads the URL in an iframe, the token appears in Referer headers.
- **Browser history/logs**: The full URL with token persists in client-side storage.
- **LLM extraction**: The token is present in the tool result that the LLM processes; a prompt injection could exfiltrate it.
- **Logging**: MCP clients may log tool results, persisting the token to disk.

### Existing Mitigations

- `content[0].text` already correctly uses `publicUrl` (the author was aware of this concern).
- MCP-UI can be disabled via `ENABLE_MCP_UI=false` or `--disable-mcp-ui`.
- The bug only affects MCP-UI clients (Goose), not MCP Apps clients (Claude Desktop, VS Code).
- However, MCP-UI is **enabled by default**, making all Goose users affected.

### Verdict

**CONFIRMED_VALID** at **high confidence**. The fix is minimal (1 source line + 2 regression tests), non-breaking, and aligns with the existing design intent.