### PR TITLE
fix: upgrade npm in Dockerfile to resolve CVE-2026-33750 (brace-expansion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - chore: upgrade @opentelemetry/\* packages to latest (fixes protobufjs GHSA-xq3m-2v4x-88gg critical CVE) (#183)
 - **CVE-2026-33750**: Added `overrides` for `brace-expansion` to `^2.0.3` — eliminates vulnerable `1.1.14` installs nested under `@eslint/config-array`, `@eslint/eslintrc`, and `eslint` via `minimatch@3.1.5`
+- **CVE-2026-33750 (Docker)**: Upgrade npm to `11.16.0` in Dockerfile — `node:22-slim` ships with npm 10.9.8 which bundles `brace-expansion` 2.0.2 internally; upgrading npm replaces it with 5.0.6 (patched)
 
 ### Breaking Changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:22-slim
 
+# Upgrade npm to fix CVE-2026-33750 (brace-expansion < 2.0.3 bundled in npm 10.x)
+RUN npm install -g npm@11.16.0
+
 # Create app directory
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

Prisma's container scanner flags CVE-2026-33750 (`brace-expansion` 2.0.2) in the Docker image even after PR #188 added npm `overrides` to `^2.0.3`.

**Why `overrides` alone isn't enough:**

The `overrides` in `package.json` only affect the app's `node_modules/` during `npm install`. They cannot touch npm's own internally bundled packages. The `node:22-slim` base image ships with npm 10.9.8, which bundles its own copy of `brace-expansion` at:

```
/usr/local/lib/node_modules/npm/node_modules/brace-expansion/  ← 2.0.2 (what Prisma flags)
/app/node_modules/brace-expansion/                              ← 2.0.3+ (fixed by overrides ✓)
```

Prisma scans the entire image filesystem and finds the copy inside npm — regardless of what's in `/app/node_modules`.

**Why not npm 10.x?** npm 10.x (latest: 10.9.8) still bundles `brace-expansion` 2.0.2. There is no patched npm 10.x release available.

## Fix

Upgrade npm to 11.16.0 in the Dockerfile. npm 11.x bundles `brace-expansion` 5.0.6 (patched).

```dockerfile
RUN npm install -g npm@11.16.0
```

The npm upgrade is build-time only — the final `CMD` runs `node` directly, so npm 11 is never in the runtime path.

## Verification

Full before/after check showing both npm-internal and app-level copies:

**Before** (without the fix — same build structure with `COPY package*.json` + `RUN npm install --ignore-scripts`):
```
$ docker run --rm mcp-server:no-fix sh -c "
  echo '=== npm internal ===' &&
  find /usr/local/lib/node_modules/npm -name 'package.json' -path '*/brace-expansion/package.json' | xargs grep '\"version\"' &&
  echo '=== app node_modules ===' &&
  find /app/node_modules -name 'package.json' -path '*/brace-expansion/package.json' | xargs grep '\"version\"'
"
```

<img width="1063" height="226" alt="image" src="https://github.com/user-attachments/assets/191f8d62-b342-455e-8f98-16eb2b83ce05" />


**After** (with `RUN npm install -g npm@11.16.0`):
```
$ docker run --rm mcp-server:scan-test sh -c "
  echo '=== npm internal ===' &&
  find /usr/local/lib/node_modules/npm -name 'package.json' -path '*/brace-expansion/package.json' | xargs grep '\"version\"' &&
  echo '=== app node_modules ===' &&
  find /app/node_modules -name 'package.json' -path '*/brace-expansion/package.json' | xargs grep '\"version\"'
"
```

<img width="1059" height="240" alt="image" src="https://github.com/user-attachments/assets/524df488-3977-4f97-9ffa-1fec14766f40" />


Both layers are clean: npm-internal upgraded to 5.0.6, app `node_modules` all at 2.1.1 (above the required 2.0.3 threshold).