### PR TITLE
fix(static-map): never embed Mapbox access token in tool result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Security
 
+- **static_map_image_tool**: Stop embedding the Mapbox access token in tool results. Previously the tool returned a `createUIResource({ iframeUrl })` whose URL carried the caller's `?access_token=` query param, leaking the secret token via the MCP-UI resource item. The credentialed URL is now only used server-side to fetch the image, which is returned inline as base64. The tool's `meta.ui.resourceUri` declaration is removed (the iframe path required the credentialed URL to function and cannot be reinstated without leaking). A regression test asserts the access token does not appear in any content item.
 - chore: upgrade @opentelemetry/\* packages to latest (fixes protobufjs GHSA-xq3m-2v4x-88gg critical CVE) (#183)
 - **CVE-2026-33750**: Added `overrides` for `brace-expansion` to `^2.0.3` — eliminates vulnerable `1.1.14` installs nested under `@eslint/config-array`, `@eslint/eslintrc`, and `eslint` via `minimatch@3.1.5`
 - **CVE-2026-33750 (Docker)**: Upgrade npm to `11.16.0` in Dockerfile — `node:22-slim` ships with npm 10.9.8 which bundles `brace-expansion` 2.0.2 internally; upgrading npm replaces it with 5.0.6 (patched)

--- a/src/tools/static-map-image-tool/StaticMapImageTool.ts
+++ b/src/tools/static-map-image-tool/StaticMapImageTool.ts
@@ -3,13 +3,11 @@
 
 import { randomUUID, randomBytes } from 'node:crypto';
 import type { z } from 'zod';
-import { createUIResource } from '@mcp-ui/server';
 import { MapboxApiBasedTool } from '../MapboxApiBasedTool.js';
 import type { HttpRequest } from '../../utils/types.js';
 import { StaticMapImageInputSchema } from './StaticMapImageTool.input.schema.js';
 import type { OverlaySchema } from './StaticMapImageTool.input.schema.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { isMcpUiEnabled } from '../../config/toolConfig.js';
 import { temporaryResourceManager } from '../../utils/temporaryResourceManager.js';
 
 // Images larger than this threshold are stored as temporary resources instead
@@ -29,15 +27,6 @@ export class StaticMapImageTool extends MapboxApiBasedTool<
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true
-  };
-  readonly meta = {
-    ui: {
-      resourceUri: 'ui://mapbox/static-map/index.html',
-      csp: {
-        connectDomains: ['https://api.mapbox.com'],
-        resourceDomains: ['https://api.mapbox.com']
-      }
-    }
   };
 
   constructor(params: { httpRequest: HttpRequest }) {
@@ -161,22 +150,6 @@ export class StaticMapImageTool extends MapboxApiBasedTool<
       // Image is small enough to inline as base64
       const base64Data = Buffer.from(buffer).toString('base64');
       content.push({ type: 'image', data: base64Data, mimeType });
-    }
-
-    // Conditionally add MCP-UI resource if enabled (backward compatibility)
-    if (isMcpUiEnabled()) {
-      const uiResource = createUIResource({
-        uri: `ui://mapbox/static-map/${input.style}/${lng},${lat},${input.zoom}`,
-        content: {
-          type: 'externalUrl',
-          iframeUrl: url
-        },
-        encoding: 'text',
-        uiMetadata: {
-          'preferred-frame-size': [`${width}px`, `${height}px`]
-        }
-      });
-      content.push(uiResource);
     }
 
     return {

--- a/test/tools/static-map-image-tool/StaticMapImageTool.test.ts
+++ b/test/tools/static-map-image-tool/StaticMapImageTool.test.ts
@@ -722,8 +722,8 @@ describe('StaticMapImageTool', () => {
     });
   });
 
-  describe('MCP-UI support', () => {
-    it('includes UIResource when MCP-UI is enabled (default)', async () => {
+  describe('credential safety', () => {
+    it('never includes the Mapbox access token in any content item', async () => {
       const { httpRequest } = setupHttpRequest();
 
       const result = await new StaticMapImageTool({ httpRequest }).run({
@@ -734,70 +734,30 @@ describe('StaticMapImageTool', () => {
       });
 
       expect(result.isError).toBe(false);
-      expect(result.content).toHaveLength(3); // URL + image + UIResource
-      expect(result.content[0].type).toBe('text');
-      expect(result.content[1].type).toBe('image');
-      expect(result.content[2].type).toBe('resource');
-      if (result.content[2].type === 'resource') {
-        expect(result.content[2].resource.uri).toMatch(
-          /^ui:\/\/mapbox\/static-map\//
-        );
-      }
+
+      // The Mapbox access token must never appear in any content item —
+      // not in text, not in image URLs, not embedded in resource bodies.
+      const tokenValue = process.env.MAPBOX_ACCESS_TOKEN!;
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain('access_token=');
+      expect(serialized).not.toContain(tokenValue);
     });
 
-    it('does not include UIResource when MCP-UI is disabled', async () => {
-      // Set environment variable to disable MCP-UI
-      const originalEnv = process.env.ENABLE_MCP_UI;
-      process.env.ENABLE_MCP_UI = 'false';
-
-      try {
-        const { httpRequest } = setupHttpRequest();
-
-        const result = await new StaticMapImageTool({ httpRequest }).run({
-          center: { longitude: -74.006, latitude: 40.7128 },
-          zoom: 12,
-          size: { width: 600, height: 400 },
-          style: 'mapbox/streets-v12'
-        });
-
-        expect(result.isError).toBe(false);
-        expect(result.content).toHaveLength(2); // URL + image, no UIResource
-        expect(result.content[0].type).toBe('text');
-      } finally {
-        // Restore environment variable
-        if (originalEnv !== undefined) {
-          process.env.ENABLE_MCP_UI = originalEnv;
-        } else {
-          delete process.env.ENABLE_MCP_UI;
-        }
-      }
-    });
-
-    it('UIResource includes correct iframe URL and dimensions', async () => {
+    it('returns only text + image content (no externalUrl iframe)', async () => {
       const { httpRequest } = setupHttpRequest();
 
       const result = await new StaticMapImageTool({ httpRequest }).run({
-        center: { longitude: -122.4194, latitude: 37.7749 },
-        zoom: 13,
-        size: { width: 800, height: 600 },
-        style: 'mapbox/satellite-streets-v12'
+        center: { longitude: -74.006, latitude: 40.7128 },
+        zoom: 12,
+        size: { width: 600, height: 400 },
+        style: 'mapbox/streets-v12'
       });
 
       expect(result.isError).toBe(false);
-      // UIResource is at index 2 (after URL text and base64 image)
-      if (result.content[2]?.type === 'resource') {
-        expect(result.content[2].resource.uri).toContain(
-          '-122.4194,37.7749,13'
-        );
-        // Check that UIMetadata has preferred dimensions
-        if ('uiMetadata' in result.content[2].resource) {
-          const metadata = result.content[2].resource.uiMetadata as Record<
-            string,
-            unknown
-          >;
-          expect(metadata['preferred-frame-size']).toEqual(['800px', '600px']);
-        }
-      }
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[1].type).toBe('image');
+      expect(result.content.some((c) => c.type === 'resource')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

`static_map_image_tool` was embedding the caller's Mapbox secret (`sk.*`) token into its tool-result `content[]`. Tool text was clean (`publicUrl` without credentials), but the MCP-UI resource carried a credentialed `iframeUrl = publicUrl + '?access_token=' + accessToken`, which serializes into `content[]` and ships back to the LLM and any tool-response observer.

This patch removes the leak vector with the smallest possible diff to `main`.

## What changed

- **`src/tools/static-map-image-tool/StaticMapImageTool.ts`**
  - Drop `createUIResource` import and the conditional `if (isMcpUiEnabled())` push — the credentialed URL no longer escapes the `httpRequest(url)` call site.
  - Drop the tool's `meta.ui.resourceUri` declaration. The iframe path needed the credentialed URL to render the image client-side; it cannot be reinstated without leaking. The image is returned inline as `type: 'image'` base64 (existing behavior, unchanged).
  - Drop the now-unused `isMcpUiEnabled` import.

- **`test/tools/static-map-image-tool/StaticMapImageTool.test.ts`**
  - Replace the broken `describe('MCP-UI support', …)` block with a regression test that JSON-stringifies the entire tool result and asserts neither the literal `access_token=` nor the configured token value appear in any content item, and that the result is exactly `[text, image]` with no `resource` content.

- **`CHANGELOG.md`** — entry under `## Unreleased > ### Security`.

## What is intentionally not changed

- `StaticMapUIResource` (`ui://mapbox/static-map/index.html`) is left registered in `resourceRegistry.ts`. It is no longer reachable through the normal MCP App flow once the tool drops `meta.ui.resourceUri`, and its HTML fetches `publicUrl` (no token) client-side and 401s — no leak surface. Removing the resource file and registry entry is a follow-up cleanup, kept out of this PR to keep the diff minimal.
- `@mcp-ui/server` dependency is left in `package.json` — other tools still import it. Removing it is a larger refactor (see the broader MCP-UI cleanup work).
- Other tools that use `createUIResource` (directions, isochrone, etc.) are not audited here — they accept inputs and emit GeoJSON, none construct a URL that bears the access token in their resource payloads. Out of scope for this hotfix.

## Test plan

- [x] `npm test` — 727 tests pass across 58 files
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged)
- [x] New regression test fails against the unpatched tool and passes with the patch
