### PR TITLE
chore: migrate Docker base image from node:22-slim to node:22-alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- **Docker**: Migrate base image from `node:22-slim` (Debian Bookworm) to `node:22-alpine`. Alpine carries no gnutls library and uses OpenSSL directly, removing a class of OS-level package vulnerabilities present in the Debian slim image. Also swaps `npm install` for `npm ci` in the install step for reproducible, lockfile-exact builds.
+
 ## 0.12.3 - 2026-06-11
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:22-alpine
 
 # Upgrade npm to fix CVE-2026-33750 (brace-expansion < 2.0.3 bundled in npm 10.x)
 RUN npm install -g npm@11.16.0
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies - completely skip prepare scripts during Docker build
-RUN npm install --ignore-scripts
+RUN npm ci --ignore-scripts
 
 # Copy the rest of the application
 COPY . .


### PR DESCRIPTION
## Summary

Migrates the Docker base image from `node:22-slim` (Debian Bookworm) to `node:22-alpine`. Also swaps `npm install` for `npm ci` in the install step.

`node:22-slim` ships several Debian system packages not needed by this server. Alpine uses OpenSSL directly and omits the gnutls library, removing a class of OS-level package vulnerabilities carried by the Debian slim base.

`npm ci` installs exactly what is in `package-lock.json` rather than re-resolving version ranges, making Docker builds reproducible and failing loudly if the lockfile and `package.json` diverge.

## Test plan

- [x] `docker build .` completes without errors on the Alpine base
- [x] Full test suite passes when run inside the built container (`docker run --rm <image> sh -c "cd /app && npm test"`)
- [x] MCP stdio smoke test: `initialize` + `tools/list` handshake completes; all 28 tools register correctly
- [x] Live API calls verified against three tools inside the running container — all returned correct results

<details>
<summary>search_and_geocode_tool — forward geocode "Eiffel Tower, Paris"</summary>

```json
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_and_geocode_tool","arguments":{"q":"Eiffel Tower, Paris"}}}
```

Returned multiple ranked results including the Eiffel Tower in Paris, France with correct coordinates.
</details>

<details>
<summary>reverse_geocode_tool — coordinates 40.7484, -73.9857</summary>

```json
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"reverse_geocode_tool","arguments":{"longitude":-73.9857,"latitude":40.7484}}}
```

Returned:
```
1. 350 Fifth Avenue (350 Fifth Avenue)
   Address: 350 Fifth Avenue, New York, New York 10118, United States
   Coordinates: 40.74843, -73.985667
   Type: address
```
</details>

<details>
<summary>directions_tool — driving route SF → Oakland</summary>

```json
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"directions_tool","arguments":{"coordinates":[{"longitude":-122.4194,"latitude":37.7749},{"longitude":-122.2712,"latitude":37.8044}],"routing_profile":"mapbox/driving"}}}
```

Returned a route via I-80 East, duration 1522s, distance 19848m, average speed 66 kph.
</details>

## Notes

Alpine uses musl libc instead of glibc. This server has no native addons compiled against glibc, so no compatibility issues are expected. If a future dependency introduces a native addon with glibc requirements, the base image choice should be revisited at that point.