### PR TITLE
chore: remove libgnutls30 from Docker runtime image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- **Docker**: Remove `libgnutls30` from the runtime image via `dpkg --remove --force-depends`. The package is only depended on by `apt`, which is not needed at runtime. `libgnutls30` is not called by Node.js (which uses OpenSSL for TLS) and was present solely as a transitive system dependency of the Debian slim base.
+
 ## 0.12.3 - 2026-06-11
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:22-slim
 
+# Remove gnutls from the runtime image. libgnutls30 is only depended on by apt,
+# which is not needed at runtime. Force-remove after all apt operations are done.
+RUN dpkg --remove --force-depends libgnutls30
+
 # Upgrade npm to fix CVE-2026-33750 (brace-expansion < 2.0.3 bundled in npm 10.x)
 RUN npm install -g npm@11.16.0
 


### PR DESCRIPTION
## Summary

Removes `libgnutls30` from the `node:22-slim` runtime image. The package is present in the Debian slim base solely as a dependency of `apt`. Since `apt` is not needed at runtime, `libgnutls30` can be force-removed after all package operations are complete without affecting the running server.

Node.js uses OpenSSL for TLS — `libgnutls30` is not called by any code path in this server and was an unused transitive system dependency.

## Test plan

- [x] `docker build .` completes without errors; `libgnutls30` removal is confirmed in build output
- [x] Full test suite passes when run inside the built container (`docker run --rm <image> sh -c "cd /app && npm test"`)
- [x] MCP stdio smoke test: `initialize` + `tools/list` handshake completes; all 28 tools register correctly
- [x] Live API calls verified against three tools inside the container: `search_and_geocode_tool`, `reverse_geocode_tool`, and `directions_tool` — all returned correct results

<details>
<summary>search_and_geocode_tool — forward geocode "Eiffel Tower, Paris"</summary>

```json
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_and_geocode_tool","arguments":{"q":"Eiffel Tower, Paris"}}}
```

Returned multiple ranked results including the Eiffel Tower in Paris, France with correct coordinates.
</details>

<details>
<summary>reverse_geocode_tool — coordinates 40.7484, -73.9857</summary>

```json
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"reverse_geocode_tool","arguments":{"longitude":-73.9857,"latitude":40.7484}}}
```

Returned:
```
1. 350 Fifth Avenue (350 Fifth Avenue)
   Address: 350 Fifth Avenue, New York, New York 10118, United States
   Coordinates: 40.74843, -73.985667
   Type: address
```
</details>

<details>
<summary>directions_tool — driving route SF → Oakland</summary>

```json
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"directions_tool","arguments":{"coordinates":[{"longitude":-122.4194,"latitude":37.7749},{"longitude":-122.2712,"latitude":37.8044}],"routing_profile":"mapbox/driving"}}}
```

Returned a route via I-80 East, duration 1522s, distance 19848m, average speed 66 kph.
</details>

## Notes

`libgnutls30` is removed with `dpkg --remove --force-depends` because `apt` lists it as a dependency. This is safe post-build: `apt` is not used at container runtime and the server has no dependency on gnutls.