### PR TITLE
chore: bump version to 0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.12.4 - 2026-06-15
+
 ### Changed
 
 - **Docker**: Remove `libgnutls30` from the runtime image via `dpkg --remove --force-depends`. The package is only depended on by `apt`, which is not needed at runtime. `libgnutls30` is not called by Node.js (which uses OpenSSL for TLS) and was present solely as a transitive system dependency of the Debian slim base.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "dxt_version": "0.1",
   "display_name": "Mapbox MCP Server",
   "name": "@mapbox/mcp-server",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Mapbox MCP server.",
   "author": {
     "name": "Mapbox, Inc."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mcp-server",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mcp-server",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mcp-server",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Mapbox MCP server.",
   "mcpName": "io.github.mapbox/mcp-server",
   "main": "./dist/commonjs/index.js",

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/mapbox/mcp-server",
     "source": "github"
   },
-  "version": "0.12.3",
+  "version": "0.12.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "runtimeHint": "npx",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "identifier": "@mapbox/mcp-server",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump following the release of v0.12.4. The GitHub release was created before the version files were updated — this PR brings `package.json`, `package-lock.json`, `manifest.json`, `server.json`, and `CHANGELOG.md` into sync with the published tag.

After merge, the `v0.12.4` tag will need to be moved to this commit so the publisher workflow validates against the correct version.