### PR TITLE
docs: add Gamut setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ For more information about Mapbox access tokens, see the [Mapbox documentation o
 For detailed setup instructions for different integrations, refer to the following guides:
 
 - [Claude Desktop Setup](./docs/claude-desktop-setup.md) - Instructions for configuring Claude Desktop to work with this MCP server
+- [Gamut Setup](./docs/gamut-setup.md) - Connecting Gamut AI agents to Mapbox's geospatial tools
 - [Goose Setup](./docs/goose-setup.md) - Setting up Goose AI agent framework
 - [VS Code Setup](./docs/vscode-setup.md) - Setting up a development environment in Visual Studio Code
 - [Cursor AI IDE Setup](./docs/cursor-setup.md) - Setting up a development environment in Cursor AI IDE

--- a/docs/gamut-setup.md
+++ b/docs/gamut-setup.md
@@ -1,0 +1,10 @@
+# Gamut Setup
+
+Connect the Mapbox MCP Server to a [Gamut](https://www.gamut.so/mcp/developer-tools/mapbox) agent in a few steps:
+
+1. In your Gamut agent, go to **Connections** and click **Add Connection**.
+2. Search for **Mapbox** and click **+** to add it.
+3. When prompted, enter your Mapbox access token to authenticate.
+4. Try a prompt like "Show me a map of downtown San Francisco" to verify the connection.
+
+For more details on available tools and features, see the [main README](../README.md).


### PR DESCRIPTION
Adds a setup guide for connecting [Gamut](https://www.gamut.so) agents to the Mapbox MCP Server, and lists it in the Integration Guides section of the README.

Gamut is an AI agent platform with native MCP support. Users can connect to the Mapbox MCP Server directly from the Gamut interface — go to **Connections**, click **Add Connection**, search for **Mapbox**, and authenticate with their access token.