### PR TITLE
Add beacon.json for Beacon discovery listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,3 +607,9 @@ This MCP server is officially maintained by Mapbox, Inc. We provide:
 ---
 
 [MIT License](LICENSE.md)
+
+## Discovery
+
+[![Beacon Verified](https://registry-ruby.vercel.app/api/v1/agents/mapbox%2Fmcp-server/badge.svg)](https://portal-five-phi-54.vercel.app/?q=mapbox%2Fmcp-server)
+
+Listed on [Beacon](https://portal-five-phi-54.vercel.app) — searchable index of open-source MCP servers.

--- a/beacon.json
+++ b/beacon.json
@@ -1,0 +1,22 @@
+{
+  "beacon_manifest": "0.1",
+  "id": "mapbox/mcp-server",
+  "name": "Mcp Server",
+  "description": "Open-source AI agent \u2014 mapbox, model, context, protocol.",
+  "capabilities": [
+    "mapbox",
+    "model",
+    "context",
+    "protocol",
+    "mcp",
+    "server"
+  ],
+  "interfaces": [
+    {
+      "type": "mcp",
+      "endpoint": "https://github.com/mapbox/mcp-server"
+    }
+  ],
+  "source": "https://github.com/mapbox/mcp-server",
+  "homepage": "https://github.com/mapbox/mcp-server"
+}


### PR DESCRIPTION
Adds Beacon Agent Manifest v0.1 for capability search on https://portal-five-phi-54.vercel.app — opt-in metadata, no runtime changes. Spec: https://github.com/enrichgateagent-png/beacon-agent-manifest

Made with [Cursor](https://cursor.com)