### PR TITLE
docs: note that unsolicited directory/discovery listing PRs are out of scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Documentation
+
+- **CONTRIBUTING**: Clarify that unsolicited PRs adding third-party directory/discovery listings (e.g. README badges, `beacon.json`-style manifests) are out of scope and will be closed without review (#225).
+
 ## 0.12.6 - 2026-07-13
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,10 @@ A Mapbox access token with appropriate scopes is required for most tools. Set `M
 - All CI checks must pass before merging (lint, format, tests)
 - At least one maintainer approval is required
 
+### Out of Scope
+
+We do not accept PRs that add listings, badges, or manifest files for third-party directories, registries, or "discovery" services (e.g. unsolicited `README.md` badges linking to an external site, or files like `beacon.json` with no functional purpose in this project). These will be closed without review.
+
 ## Standards & Guidelines
 
 | Document                                                             | Contents                                                                   |


### PR DESCRIPTION
## Summary
- Adds an "Out of Scope" note to CONTRIBUTING.md stating that we don't accept PRs adding third-party directory/discovery listings (README badges, `beacon.json`-style manifests, etc.) with no functional value to the project.
- Prompted by #225, a spam PR adding a `beacon.json` manifest and a README badge for an unverified third-party "agent discovery" site.

## Test plan
- [x] Docs-only change; no code paths affected
- [x] CHANGELOG.md updated per contributing guidelines