### PR TITLE
fix: map_matching_tool returns graceful error instead of MCP -32602 on NoMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- **map_matching_tool**: When the Map Matching API can't match a trace (e.g. `code: "NoMatch"` for distant/unmatchable coordinates), the tool now returns a clear `isError` text result instead of crashing with `MCP error -32602: Output validation error` — the API omits `tracepoints`/`matchings` in this case, which previously violated the tool's output schema and was returned as `structuredContent` anyway, triggering the MCP SDK's output validation. The same schema-violating `structuredContent` could also be returned for a `code: "Ok"` response that otherwise failed schema validation (e.g. a `confidence` out of range); that fallback now also returns a graceful `isError` result instead of the raw invalid payload. `tracepoints` and `matchings` are also now `.optional()` in the output schema as a defensive measure. (AGI-1021)
+
 ## 0.12.7 - 2026-07-20
 
 ### Fixed

--- a/src/tools/map-matching-tool/MapMatchingTool.output.schema.ts
+++ b/src/tools/map-matching-tool/MapMatchingTool.output.schema.ts
@@ -49,8 +49,8 @@ const MatchingSchema = z.object({
 // Main output schema
 export const MapMatchingOutputSchema = z.object({
   code: z.string(),
-  matchings: z.array(MatchingSchema),
-  tracepoints: z.array(TracepointSchema.nullable())
+  matchings: z.array(MatchingSchema).optional(),
+  tracepoints: z.array(TracepointSchema.nullable()).optional()
 });
 
 export type MapMatchingOutput = z.infer<typeof MapMatchingOutputSchema>;

--- a/src/tools/map-matching-tool/MapMatchingTool.ts
+++ b/src/tools/map-matching-tool/MapMatchingTool.ts
@@ -119,6 +119,22 @@ export class MapMatchingTool extends MapboxApiBasedTool<
 
     const data = (await response.json()) as MapMatchingOutput;
 
+    // The Map Matching API returns 200 with a non-"Ok" code (e.g. "NoMatch",
+    // "NoSegment") when it can't match the trace, and omits tracepoints/matchings
+    // in that case. Surface this as a tool error rather than structured content
+    // so the MCP SDK's output schema validation is skipped for this response.
+    if (data.code !== 'Ok') {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Map Matching API could not match the trace (code: ${data.code}). Try adjusting the coordinates or radiuses.`
+          }
+        ],
+        isError: true
+      };
+    }
+
     // Validate the response against our output schema
     try {
       const validatedData = MapMatchingOutputSchema.parse(data);
@@ -131,16 +147,23 @@ export class MapMatchingTool extends MapboxApiBasedTool<
         isError: false
       };
     } catch (validationError) {
-      // If validation fails, return the raw result anyway with a warning
-      this.log(
-        'warning',
-        `Schema validation warning: ${validationError instanceof Error ? validationError.message : String(validationError)}`
-      );
+      // The API responded with code: 'Ok' but the payload still doesn't match
+      // our output schema. Never return schema-violating structuredContent -
+      // the MCP SDK rejects it with the same -32602 this fix is meant to avoid.
+      const message =
+        validationError instanceof Error
+          ? validationError.message
+          : String(validationError);
+      this.log('warning', `Schema validation warning: ${message}`);
 
       return {
-        content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
-        structuredContent: data,
-        isError: false
+        content: [
+          {
+            type: 'text',
+            text: `Map Matching API returned a response that didn't match the expected format: ${message}`
+          }
+        ],
+        isError: true
       };
     }
   }

--- a/test/tools/map-matching-tool/MapMatchingTool.test.ts
+++ b/test/tools/map-matching-tool/MapMatchingTool.test.ts
@@ -228,6 +228,55 @@ describe('MapMatchingTool', () => {
     expect(callUrl).toContain('/matching/v5/mapbox/cycling/');
   });
 
+  it('returns a graceful error when the API cannot match the trace', async () => {
+    const { httpRequest } = setupHttpRequest({
+      json: async () => ({ code: 'NoMatch' })
+    });
+
+    const tool = new MapMatchingTool({ httpRequest });
+    const result = await tool.run({
+      coordinates: [
+        { longitude: -122.4194, latitude: 37.7749 },
+        { longitude: -122.4783, latitude: 37.8199 }
+      ],
+      profile: 'walking'
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(result.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('NoMatch')
+    });
+  });
+
+  it('returns a graceful error when the API responds Ok but with a schema-invalid payload', async () => {
+    const { httpRequest } = setupHttpRequest({
+      json: async () => ({
+        code: 'Ok',
+        // confidence must be between 0 and 1 - this violates MapMatchingOutputSchema
+        matchings: [{ confidence: 5, distance: 100, duration: 10 }],
+        tracepoints: []
+      })
+    });
+
+    const tool = new MapMatchingTool({ httpRequest });
+    const result = await tool.run({
+      coordinates: [
+        { longitude: -122.4194, latitude: 37.7749 },
+        { longitude: -122.4195, latitude: 37.775 }
+      ],
+      profile: 'driving'
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(result.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining("didn't match the expected format")
+    });
+  });
+
   it('uses geojson geometries by default', async () => {
     const { httpRequest, mockHttpRequest } = setupHttpRequest({
       json: async () => sampleMapMatchingResponse


### PR DESCRIPTION
## Description

<!-- Provide a clear explanation of what has been implemented or fixed. Mention any related context, requirements, or issues. -->

`map_matching_tool` was crashing with a protocol-level MCP error (`-32602: Output validation error`) instead of returning a usable result whenever the Mapbox Map Matching API couldn't match a trace (e.g. two coordinates too far apart to snap to a route, `code: "NoMatch"`).

Root cause: the API omits `tracepoints`/`matchings` when it returns a non-`"Ok"` code, but the tool's output schema required them. The tool's existing fallback then returned this schema-violating data as `structuredContent` anyway, which the MCP SDK rejected at the protocol level before the caller ever saw a usable response.

This PR:

- Returns a graceful `isError` text result (no `structuredContent`) when the API reports a non-`Ok` code, instead of forwarding invalid data to the SDK's output validator.
- Applies the same graceful-error handling to the pre-existing schema-validation-failure fallback, where a nominally `Ok` response could still fail schema validation and hit the same crash.
- Marks `tracepoints`/`matchings` as `.optional()` on the output schema as a defensive measure.

---

## Testing

<!-- Include logs, screenshots, terminal output, or any relevant proof of successful testing. -->

- Added two unit tests covering both failure paths (a `NoMatch` response, and an `Ok` response that fails schema validation) — both assert a graceful `isError` result with no `structuredContent`.
- Full suite: `npm test` → 63 files, 759 tests passed, 0 failed.
- `npx tsc --noEmit` → no errors.
- Manually verified locally with the exact repro coordinates from the bug report: previously produced the raw `-32602` error, now returns a clear "could not match the trace" message.

---

## Checklist

- [x] Tests added or updated (`npm test` passes)
- [x] Lint passes (`npm run lint`)
- [x] `CHANGELOG.md` updated under `Unreleased`
- [x] Documentation updated if needed (README, JSDoc) — not applicable, no public API/doc changes beyond the changelog entry

---

## Additional Notes

<!-- Include any further details, follow-up items, or decisions relevant to the reviewer. -->

Scope is limited to `map_matching_tool`'s own error handling; no other tools were touched.
