### PR TITLE
fix: directions_tool exclude parameter could inject query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Security
+
+- **directions_tool: fixed query parameter injection via the `exclude` parameter.** A `point(<lng> <lat>)` exclude entry was validated by splitting on spaces and reading only the first two tokens — any extra content after them (e.g. `point(0 0 &injected=evil)`) was never inspected or rejected. That value then reached the outbound Mapbox Directions API request through a hand-rolled encoder that escaped `,`/`(`/`)`/space but not `&`/`=`, concatenated directly onto the query string rather than through `URLSearchParams`. Together these let a caller-supplied `exclude` value add or override arbitrary query parameters on the authenticated Directions API request. Fixed by (1) requiring a `point(...)` entry's interior to be exactly two numbers and nothing else, and (2) building the `exclude` parameter through `URLSearchParams` like every other parameter, so it's always correctly percent-encoded regardless of content. Applied to both the server-side request builder and its hand-ported client-side twin in the map preview iframe.
+
 ### Fixed
 
 - **map_matching_tool**: When the Map Matching API can't match a trace (e.g. `code: "NoMatch"` for distant/unmatchable coordinates), the tool now returns a clear `isError` text result instead of crashing with `MCP error -32602: Output validation error` — the API omits `tracepoints`/`matchings` in this case, which previously violated the tool's output schema and was returned as `structuredContent` anyway, triggering the MCP SDK's output validation. The same schema-violating `structuredContent` could also be returned for a `code: "Ok"` response that otherwise failed schema validation (e.g. a `confidence` out of range); that fallback now also returns a graceful `isError` result instead of the raw invalid payload. `tracepoints` and `matchings` are also now `.optional()` in the output schema as a defensive measure. (AGI-1021)

--- a/src/resources/ui-apps/directionsAppHtml.ts
+++ b/src/resources/ui-apps/directionsAppHtml.ts
@@ -138,14 +138,6 @@ ${initialDataScript}
     return dateTime;
   }
 
-  function encodeExcludeClient(value) {
-    return value
-      .replace(/,/g, '%2C')
-      .replace(/\\(/g, '%28')
-      .replace(/\\)/g, '%29')
-      .replace(/ /g, '%20');
-  }
-
   function buildDirectionsApiUrl(params, publicToken, apiEndpoint) {
     var coords = params.coordinates
       .map(function(c) { return c.longitude + ',' + c.latitude; })
@@ -180,25 +172,21 @@ ${initialDataScript}
       qp.append('max_weight', String(params.max_weight));
     }
     qp.append('steps', 'true');
-
-    var queryString = qp.toString();
     if (params.exclude) {
-      queryString += '&exclude=' + encodeExcludeClient(params.exclude);
+      qp.append('exclude', params.exclude);
     }
 
-    return apiEndpoint + 'directions/v5/' + profile + '/' + encodedCoords + '?' + queryString;
+    return apiEndpoint + 'directions/v5/' + profile + '/' + encodedCoords + '?' + qp.toString();
   }
   // Exposed so the parity test (Node vm sandbox) can call this in isolation.
   window.__buildDirectionsApiUrl = buildDirectionsApiUrl;
 
-  // Params arrive via postMessage and are untrusted: they get interpolated
-  // into the request URL, so validate the pieces our encoding does not
-  // neutralize. routing_profile is spliced into the URL path unencoded, and
-  // encodeExcludeClient only escapes ',', '(', ')' and spaces — characters
-  // like '&' or '../' path segments would otherwise let a hostile sibling
-  // frame reshape the request. Server-side input is zod-validated before it
-  // reaches buildDirectionsRequestUrl; this mirrors those guarantees for
-  // the client copy.
+  // Params arrive via postMessage and are untrusted. coordinates and
+  // exclude are both passed through URLSearchParams above, which
+  // percent-encodes them safely regardless of content — routing_profile is
+  // the one value spliced into the URL *path* unencoded, so its shape is
+  // restricted here. The exclude check below is defense-in-depth against a
+  // malformed ref, not a compensating control for an encoding gap.
   function isSafeDirectionsParams(params) {
     if (!params || !Array.isArray(params.coordinates)) return false;
     if (params.coordinates.length < 2) return false;

--- a/src/tools/directions-tool/DirectionsTool.input.schema.ts
+++ b/src/tools/directions-tool/DirectionsTool.input.schema.ts
@@ -221,17 +221,25 @@ export const DirectionsInputSchema = z.object({
         // Check if it's a point exclusion
         if (item.startsWith('point(') && item.endsWith(')')) {
           const coordStr = item.substring(6, item.length - 1).trim();
-          const [lngStr, latStr] = coordStr.split(' ');
+          // Require exactly two space-separated numbers and nothing else.
+          // Destructuring `coordStr.split(' ')` previously read only the
+          // first two tokens and silently dropped anything past them, so a
+          // third token (e.g. an "&param=value" fragment) was never
+          // inspected and rode along unvalidated into the exclude value.
+          const pointMatch = /^(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)$/.exec(
+            coordStr
+          );
 
-          // Validate both parts exist
-          if (!lngStr || !latStr) {
+          if (!pointMatch) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              message: `Invalid point format in exclude parameter: '${item}'. Format should be point(<lng> <lat>)`,
+              message: `Invalid point format in exclude parameter: '${item}'. Format should be point(<lng> <lat>) with exactly one number for longitude and one for latitude`,
               path: []
             });
             continue;
           }
+
+          const [, lngStr, latStr] = pointMatch;
 
           // Parse and validate longitude
           const lng = Number(lngStr);

--- a/src/tools/directions-tool/buildDirectionsRequestUrl.ts
+++ b/src/tools/directions-tool/buildDirectionsRequestUrl.ts
@@ -16,14 +16,6 @@ export interface DirectionsRequestInput {
   max_weight?: number;
 }
 
-function encodeExclude(value: string): string {
-  return value
-    .replace(/,/g, '%2C')
-    .replace(/\(/g, '%28')
-    .replace(/\)/g, '%29')
-    .replace(/ /g, '%20');
-}
-
 /**
  * Build the Mapbox Directions v5 request URL for a given input. Shared by
  * DirectionsTool.execute() (server-side) and hand-mirrored by the
@@ -76,11 +68,9 @@ export function buildDirectionsRequestUrl(params: {
   }
 
   queryParams.append('steps', 'true');
-  let queryString = queryParams.toString();
-
   if (input.exclude) {
-    queryString += `&exclude=${encodeExclude(input.exclude)}`;
+    queryParams.append('exclude', input.exclude);
   }
 
-  return `${apiEndpoint}directions/v5/${input.routing_profile}/${encodedCoords}?${queryString}`;
+  return `${apiEndpoint}directions/v5/${input.routing_profile}/${encodedCoords}?${queryParams.toString()}`;
 }

--- a/test/tools/directions-tool/DirectionsTool.test.ts
+++ b/test/tools/directions-tool/DirectionsTool.test.ts
@@ -135,13 +135,59 @@ describe('DirectionsTool', () => {
 
     const calledUrl = mockHttpRequest.mock.calls[0][0];
     const comma = '%2C';
-    const space = '%20';
+    const space = '+'; // URLSearchParams encodes a literal space as '+'
     const openPar = '%28';
     const closePar = '%29';
     expect(calledUrl).toContain(
       `exclude=toll${comma}point${openPar}-73.95${space}40.75${closePar}`
     );
     assertHeadersSent(mockHttpRequest);
+  });
+
+  it('rejects a point() exclude entry with a trailing third token instead of silently dropping it', async () => {
+    const { httpRequest } = setupHttpRequest();
+
+    const result = await new DirectionsTool({ httpRequest }).run({
+      coordinates: [
+        { longitude: -74.0, latitude: 40.7 },
+        { longitude: -73.9, latitude: 40.8 }
+      ],
+      exclude: 'point(0 0 &injected=evil)'
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({
+      type: 'text'
+    });
+    expect((result.content[0] as { text: string }).text).toContain(
+      'Invalid point format in exclude parameter'
+    );
+  });
+
+  it('never lets exclude inject or duplicate other query parameters, even if a malformed value slipped past validation', async () => {
+    // Bypasses the schema directly to exercise the URL builder's own
+    // defense independent of the validator fix above.
+    const { buildDirectionsRequestUrl } =
+      await import('../../../src/tools/directions-tool/buildDirectionsRequestUrl.js');
+    const url = buildDirectionsRequestUrl({
+      input: {
+        coordinates: [
+          { longitude: -74.0, latitude: 40.7 },
+          { longitude: -73.9, latitude: 40.8 }
+        ],
+        routing_profile: 'mapbox/driving',
+        geometries: 'none',
+        alternatives: false,
+        exclude: 'point(0 0 &injected=evil)'
+      },
+      accessToken: 'pk.test-token',
+      apiEndpoint: 'https://api.mapbox.com/'
+    });
+
+    const params = new URLSearchParams(url.split('?')[1]);
+    expect(params.get('injected')).toBeNull();
+    expect(params.getAll('alternatives')).toEqual(['false']);
+    expect(params.get('exclude')).toBe('point(0 0 &injected=evil)');
   });
 
   it('handles fetch errors gracefully', async () => {

--- a/test/tools/directions-tool/buildDirectionsRequestUrl.test.ts
+++ b/test/tools/directions-tool/buildDirectionsRequestUrl.test.ts
@@ -70,11 +70,36 @@ describe('buildDirectionsRequestUrl', () => {
       apiEndpoint: 'https://api.mapbox.com/'
     });
 
-    expect(url).toContain('exclude=toll%2Cpoint%28-122.41%2037.785%29');
+    expect(url).toContain('exclude=toll%2Cpoint%28-122.41+37.785%29');
     expect(url).toContain('depart_at=2026-07-20T09%3A00');
     expect(url).toContain('max_height=4.5');
     expect(url).toContain('max_width=2.4');
     expect(url).toContain('max_weight=12.5');
     expect(url).toContain('alternatives=true');
+  });
+
+  it('percent-encodes exclude through URLSearchParams so it can never inject or duplicate another query parameter', () => {
+    const url = buildDirectionsRequestUrl({
+      input: {
+        coordinates: [
+          { longitude: -122.42, latitude: 37.78 },
+          { longitude: -122.4, latitude: 37.79 }
+        ],
+        routing_profile: 'mapbox/driving',
+        geometries: 'none',
+        alternatives: false,
+        // Not a value the schema would allow through, but the URL builder
+        // is a separate line of defense: even a raw '&'/'=' must come back
+        // out through URLSearchParams unable to add or override a param.
+        exclude: 'point(0 0 &injected=evil)'
+      },
+      accessToken: 'pk.test-token',
+      apiEndpoint: 'https://api.mapbox.com/'
+    });
+
+    const params = new URLSearchParams(url.split('?')[1]);
+    expect(params.get('injected')).toBeNull();
+    expect(params.getAll('alternatives')).toEqual(['false']);
+    expect(params.get('exclude')).toBe('point(0 0 &injected=evil)');
   });
 });

--- a/test/tools/directions-tool/directionsUrlParity.test.ts
+++ b/test/tools/directions-tool/directionsUrlParity.test.ts
@@ -158,4 +158,38 @@ describe('Directions URL builder parity (server vs. iframe self-fetch)', () => {
 
     expect(clientUrl).toBe(serverUrl);
   });
+
+  it('encodes an exclude value containing "&"/"=" identically on both sides, without letting it inject a query parameter', () => {
+    const input = {
+      coordinates: [
+        { longitude: -73.989, latitude: 40.733 },
+        { longitude: -73.979, latitude: 40.743 }
+      ],
+      routing_profile: 'mapbox/driving',
+      geometries: 'none' as const,
+      alternatives: false,
+      exclude: 'point(0 0 &injected=evil)'
+    };
+
+    const serverUrl = buildDirectionsRequestUrl({
+      input,
+      accessToken: 'pk.test-token',
+      apiEndpoint: 'https://api.mapbox.com/',
+      geometriesOverride: 'geojson'
+    });
+
+    const buildClientUrl = loadClientBuildUrlFn();
+    const clientUrl = buildClientUrl(
+      input,
+      'pk.test-token',
+      'https://api.mapbox.com/'
+    );
+
+    expect(clientUrl).toBe(serverUrl);
+
+    const params = new URLSearchParams(serverUrl.split('?')[1]);
+    expect(params.get('injected')).toBeNull();
+    expect(params.getAll('alternatives')).toEqual(['false']);
+    expect(params.get('exclude')).toBe('point(0 0 &injected=evil)');
+  });
 });


### PR DESCRIPTION
## What changed

Fixes a query-parameter-injection defect in `directions_tool`'s `exclude` parameter, present in both the server-side request builder and its hand-ported client-side twin in the map preview iframe.

## The underlying issue

A `point(<lng> <lat>)` exclude entry was validated by splitting on spaces and destructuring only the first two tokens:

```ts
const [lngStr, latStr] = coordStr.split(' ');
```

Any extra content after those two tokens — e.g. `point(0 0 &injected=evil)` — was silently dropped by the destructuring and never inspected or rejected.

That raw value then reached the outbound Mapbox Directions API request through a hand-rolled encoder that escaped `,`, `(`, `)`, and space, but not `&` or `=`:

```ts
function encodeExclude(value: string): string {
  return value
    .replace(/,/g, '%2C')
    .replace(/\(/g, '%28')
    .replace(/\)/g, '%29')
    .replace(/ /g, '%20');
}
```

...and was concatenated directly onto the query string rather than through `URLSearchParams`, which every other parameter uses:

```ts
queryString += `&exclude=${encodeExclude(input.exclude)}`;
```

Together, these two defects let a caller-supplied `exclude` value add new query parameters or override existing ones (e.g. `alternatives`) on the authenticated Directions API request.

## Fix

1. **Validation** (`DirectionsTool.input.schema.ts`): a `point(...)` entry's interior must now match `/^(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)$/` — exactly two numbers and nothing else — instead of accepting anything past the first two space-separated tokens.
2. **Encoding** (`buildDirectionsRequestUrl.ts` and its client-side twin in `directionsAppHtml.ts`): `exclude` is now appended via `queryParams.append('exclude', input.exclude)` like every other parameter, instead of a hand-rolled encoder + string concatenation. `URLSearchParams` percent-encodes the full character set correctly, including `&`/`=`, which the custom encoder missed.

Applying the fix to both the server builder and the client-side self-fetch twin closes it at both call sites, even though the client twin already had an independent `isSafeDirectionsParams` regex guard that happened to reject `&`/`=` before reaching this code path.

## Testing

- Two new tests confirm a `point(...)` entry with trailing content is now rejected by the schema with a clear message, and that the URL builder itself can no longer inject/duplicate a query parameter even if a malformed value reached it directly.
- Extended the existing server/client parity test with the same injection-shaped input, confirming both sides encode it identically and safely.
- Updated one pre-existing test assertion: `URLSearchParams` encodes a literal space as `+` rather than the old encoder's `%20` — both are standard and decode identically server-side.
- Full suite passes (763 tests), typecheck/lint/build clean.

## Note on scope

This only touches `directions_tool`'s `exclude` handling. I checked for the same anti-pattern (hand-rolled encoder + manual string concatenation bypassing `URLSearchParams`) elsewhere in the codebase — it doesn't appear anywhere else.