### PR TITLE
chore: bump @modelcontextprotocol/sdk to 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   `BaseResource` carried the same pattern and got the same treatment. Its only reader was `log()`, so the practical effect there was misdirected log messages rather than misdirected client interaction, but the resource instances exported from `@mapbox/mcp-server/resources` are module-level singletons for the same reason and the shared field was the same hazard.
 
+### Dependencies
+
+- Bumped `@modelcontextprotocol/sdk` to `1.30.0`. Not adopting the `2026-07-28` spec revision this release covers (stateless request/response model, elicitation replaced by Multi Round-Trip Requests, Sampling deprecated) — that's a separate migration tracked in #245, since `directions_tool`/`search_and_geocode_tool`'s elicitation-based selection and `ground_location_tool`'s sampling-based strategy detection all depend on the mechanisms being replaced. Regenerated `patches/@modelcontextprotocol+sdk+1.30.0.patch` (previously pinned to `1.29.0`) — same patch content, applies cleanly to the new version, verified live against the built server.
+
 ## 0.14.0 - 2026-07-30
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.1.1",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.74.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
@@ -1463,12 +1463,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.1.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.74.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",

--- a/patches/@modelcontextprotocol+sdk+1.30.0.patch
+++ b/patches/@modelcontextprotocol+sdk+1.30.0.patch
@@ -1,6 +1,8 @@
+diff --git a/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js b/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js
+index 9e1c874..2de8d57 100644
 --- a/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js
 +++ b/node_modules/@modelcontextprotocol/sdk/dist/cjs/server/mcp.js
-@@ -197,15 +197,20 @@
+@@ -197,15 +197,20 @@ class McpServer {
              return;
          }
          if (!result.structuredContent) {
@@ -29,9 +31,11 @@
          }
      }
      /**
+diff --git a/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js b/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
+index 2314d88..94aaef1 100644
 --- a/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
 +++ b/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
-@@ -194,15 +194,20 @@
+@@ -194,15 +194,20 @@ export class McpServer {
              return;
          }
          if (!result.structuredContent) {


### PR DESCRIPTION
## What changed

Bumps `@modelcontextprotocol/sdk` from `1.29.0` to `1.30.0` — within the existing `^1.29.0` range, so this is really just catching the lockfile up. Also regenerates `patches/@modelcontextprotocol+sdk+1.30.0.patch` (previously pinned to `1.29.0` in its filename); the patch content is unchanged, just re-based against the new version.

## Not in scope here

This does **not** adopt the `2026-07-28` MCP spec revision this SDK version also supports (stateless request/response model, elicitation replaced by Multi Round-Trip Requests, Sampling deprecated). That's a real migration, not a version bump: `directions_tool`/`search_and_geocode_tool`'s elicitation-based selection and `ground_location_tool`'s sampling-based grounding strategy all depend on the exact mechanisms being replaced/deprecated. Tracked separately in #245.

## Verification

- Since both this repo and `mcp-devkit-server` patch `@modelcontextprotocol/sdk`'s `mcp.js` (converts SDK-level output-validation throws into warnings), the real risk here wasn't the version bump itself, it was whether the patch still applies. Ran `npx patch-package` explicitly after the bump (not just relying on `postinstall`, which swallows failures via `|| true`) — it applied cleanly with only a filename-version-mismatch warning, and I confirmed the patched (`console.warn`, not `throw`) code is actually present in the installed `dist/cjs` and `dist/esm` files, not a silent no-op.
- `npx tsc --noEmit`, `npx eslint`: clean.
- Full suite: 920/920 pass (as a bonus, the previously-failing, unrelated `urlSafety.test.ts` issue on `main` now passes too — looks like a transitive dependency shifted).
- `npm run build` succeeds.
- Live-tested the actual built server via a real MCP stdio client: connects, negotiates fine, `search_and_geocode_tool` call succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)